### PR TITLE
Update ONNX Runtime Web dists from dev and test versions to 1.18.0

### DIFF
--- a/assets/js/common_utils.js
+++ b/assets/js/common_utils.js
@@ -115,7 +115,7 @@ export const getOrtDevVersion = async () => {
 export const setupORT = async () => {
   const ortversion = document.querySelector("#ortversion");
   removeElement("onnxruntime-web");
-  let ortVersion = await getOrtDevVersion();
+  let ortVersion = "1.18.0";
   let ortLink = "";
   if (ortVersion && ortVersion.length > 4) {
     await loadScript(

--- a/demos/sd-turbo/index.js
+++ b/demos/sd-turbo/index.js
@@ -995,7 +995,7 @@ const webNnStatus = async () => {
 const setupORT = async () => {
   const ortversion = document.querySelector("#ortversion");
   removeElement("onnxruntime-web");
-  let ortVersion = await getOrtDevVersion();
+  let ortVersion = "1.18.0";
   let ortLink = "";
   if (ortVersion && ortVersion.length > 4) {
     await loadScript(

--- a/demos/stable-diffusion-1.5/index.js
+++ b/demos/stable-diffusion-1.5/index.js
@@ -213,7 +213,7 @@ function get_tensor_from_image(imageData, format) {
 const setupORT = async () => {
   const ortversion = document.querySelector("#ortversion");
   Utils.removeElement("onnxruntime-web");
-  let ortVersion = await Utils.getOrtDevVersion();
+  let ortVersion = "1.18.0";
   let ortLink = "";
   if (ortVersion && ortVersion.length > 4) {
     await Utils.loadScript(

--- a/demos/whisper-base/main.js
+++ b/demos/whisper-base/main.js
@@ -5,7 +5,7 @@
 //
 
 import { Whisper } from "./whisper.js";
-import { loadScript, removeElement, getQueryValue, getOrtDevVersion, webNnStatus, log, logError, concatBuffer, concatBufferArray, logUser, getMode } from "./utils.js";
+import { loadScript, removeElement, getQueryValue, webNnStatus, log, logError, concatBuffer, concatBufferArray, logUser, getMode } from "./utils.js";
 import VADBuilder, { VADMode, VADEvent } from "./vad/embedded.js";
 import AudioMotionAnalyzer from './static/js/audioMotion-analyzer.js?min';
 import { lcm } from "./vad/math.js";
@@ -584,18 +584,16 @@ async function processAudioBuffer() {
 const setupORT = async () => {
   const ortversion = document.querySelector('#ortversion');
   removeElement('onnxruntime-web');
-  let ortVersion = await getOrtDevVersion();
-  // let ortLink = '';
-  // if (ortVersion && ortVersion.length > 4) {
-  //     await loadScript('onnxruntime-web', `https://cdn.jsdelivr.net/npm/onnxruntime-web@${ortVersion}/dist/ort.all.min.js`);
-  //     ortLink = `https://www.npmjs.com/package/onnxruntime-web/v/${ortVersion}`
-  //     ortversion.innerHTML = `ONNX Runtime Web: <a href="${ortLink}">${ortVersion}</a>`;
-  // } else {
-  //     await loadScript('onnxruntime-web', './dist/ort.all.min.js');
-  //     ortversion.innerHTML = `ONNX Runtime Web: Test version`;
-  // }
-  await loadScript('onnxruntime-web', '../../assets/dist/ort.all.js');
-  ortversion.innerHTML = `ONNX Runtime Web: Test version`;
+  let ortVersion = "1.18.0";
+  let ortLink = '';
+  if (ortVersion && ortVersion.length > 4) {
+      await loadScript('onnxruntime-web', `https://cdn.jsdelivr.net/npm/onnxruntime-web@${ortVersion}/dist/ort.all.min.js`);
+      ortLink = `https://www.npmjs.com/package/onnxruntime-web/v/${ortVersion}`
+      ortversion.innerHTML = `ONNX Runtime Web: <a href="${ortLink}">${ortVersion}</a>`;
+  } else {
+      await loadScript('onnxruntime-web', '../../assets/dist/ort.all.min.js');
+      ortversion.innerHTML = `ONNX Runtime Web: Test version`;
+  }
 }
 
 const main = async () => {  

--- a/install.html
+++ b/install.html
@@ -214,8 +214,8 @@
         <div id='install-guides'>
             WebNN requires a compatible browser to run, and Windows* 11 v21H2 (DML 1.6.0) or higher.
             <ol>
-                <li>Download the latest <a href="https://www.microsoft.com/edge/download/insider"
-                        title="Microsoft Edge Canary">Microsoft Edge Canary</a> 
+                <li>Download the <a href="https://www.microsoft.com/edge/download/insider"
+                        title="Microsoft Edge Dev channel version">Microsoft Edge Dev channel version</a> or later
                     browser</li>
                 <li>To enable WebNN, in your browser address bar, enter <code>about://flags</code>, and then press
                     <code>Enter</code>. An Experiments page opens


### PR DESCRIPTION
The 1.18.0 version of ONNX Runtime Web was released in https://www.npmjs.com/package/onnxruntime-web?activeTab=versions , update the dists from dev and test versions to 1.18.0 in the demos.

@Adele101 PTAL