### PR TITLE
Update Safety Checker model for reduceSum with int32 input

### DIFF
--- a/demos/sd-turbo/index.js
+++ b/demos/sd-turbo/index.js
@@ -238,7 +238,7 @@ async function load_models(models) {
         modelUrl = `${config.model}/${name}/model.onnx`;
       } else if (name == "safety_checker") {
         modelNameInLog = "Safety Checker";
-        modelUrl = `${config.model}/${name}/model.onnx`;
+        modelUrl = `${config.model}/${name}/safety_checker_int32_reduceSum.onnx`;
       }
       log(`[Load] Loading model ${modelNameInLog} · ${model.size}`);
       let modelBuffer = await getModelOPFS(`sd_turbo_${name}`, modelUrl, false);


### PR DESCRIPTION
The Safety Checker model for Stable Diffusion Turbo uses reduceSum with int64 input, which caused the demo [failing on WebNN Core ML backend](https://github.com/webmachinelearning/webnn/pull/695) since the int64 is not supported on CoreML.

Use the Safety Checker model for reduceSum with int32 input converted by @Honry instead.

We did not directly use the name of the original model and overwrite it, in order to leave a record of the revision. Please do not merge this PR until the model has been uploaded into huggingface.

@Adele101 Please take a look.