### PR TITLE
[Fix] Temporarily always return true from the fp16 check + beginning of better error handling

### DIFF
--- a/assets/dist_transformers/dynamic-runs-1.19-dev/transformers.js
+++ b/assets/dist_transformers/dynamic-runs-1.19-dev/transformers.js
@@ -18534,16 +18534,8 @@ async function pipeline(
     ]);
 
     // Load model, tokenizer, and processor (if they exist)
-    let results;
-
-    try {
-      results = await loadItems(classes, model, pretrainedOptions);
-      console.log('results', results);
-      results.task = task;
-    }
-    catch(err) {
-      console.log("ERRRRRRRRROROROROROR", err);
-    }
+    const results = await loadItems(classes, model, pretrainedOptions);
+    results.task = task;
 
     (0,_utils_core_js__WEBPACK_IMPORTED_MODULE_4__.dispatchCallback)(progress_callback, {
         'status': 'ready',
@@ -26817,6 +26809,7 @@ const isFp16Supported = (function () {
                 try {
                     const adapter = await navigator.gpu.requestAdapter();
                     // cachedResult = adapter.features.has('shader-f16');
+                    // always return true for now to avoid false positive checks
                     cachedResult = true;
                 } catch (e) {
                     cachedResult = false;

--- a/assets/dist_transformers/dynamic-runs-1.19-dev/transformers.js
+++ b/assets/dist_transformers/dynamic-runs-1.19-dev/transformers.js
@@ -18534,14 +18534,23 @@ async function pipeline(
     ]);
 
     // Load model, tokenizer, and processor (if they exist)
-    const results = await loadItems(classes, model, pretrainedOptions);
-    results.task = task;
+    let results;
+
+    try {
+      results = await loadItems(classes, model, pretrainedOptions);
+      console.log('results', results);
+      results.task = task;
+    }
+    catch(err) {
+      console.log("ERRRRRRRRROROROROROR", err);
+    }
 
     (0,_utils_core_js__WEBPACK_IMPORTED_MODULE_4__.dispatchCallback)(progress_callback, {
         'status': 'ready',
         'task': task,
         'model': model,
     });
+    
 
     const pipelineClass = pipelineInfo.pipeline;
     return new pipelineClass(results);
@@ -26807,7 +26816,8 @@ const isFp16Supported = (function () {
             } else {
                 try {
                     const adapter = await navigator.gpu.requestAdapter();
-                    cachedResult = adapter.features.has('shader-f16');
+                    // cachedResult = adapter.features.has('shader-f16');
+                    cachedResult = true;
                 } catch (e) {
                     cachedResult = false;
                 }

--- a/assets/dist_transformers/dynamic-runs-1.19-dev/transformers.js
+++ b/assets/dist_transformers/dynamic-runs-1.19-dev/transformers.js
@@ -26809,7 +26809,7 @@ const isFp16Supported = (function () {
                 try {
                     const adapter = await navigator.gpu.requestAdapter();
                     // cachedResult = adapter.features.has('shader-f16');
-                    // always return true for now to avoid false positive checks
+                    // Always return true for now to avoid false positive checks.
                     cachedResult = true;
                 } catch (e) {
                     cachedResult = false;

--- a/demos/image-classification/index.js
+++ b/demos/image-classification/index.js
@@ -192,9 +192,7 @@ const main = async () => {
     uploadImage.disabled = true;
     classify.disabled = true;
     log(`[Error] ${error}`);
-    log(
-      `[Error] Your device probably doesn't have a supported GPU`
-    );
+    log(`[Error] Your device probably doesn't have a supported GPU`);
   }
 };
 

--- a/demos/image-classification/index.js
+++ b/demos/image-classification/index.js
@@ -28,8 +28,7 @@ transformers.env.allowRemoteModels = useRemoteModels;
 transformers.env.allowLocalModels = !useRemoteModels;
 log('[Transformer.js] env.allowRemoteModels: ' + transformers.env.allowRemoteModels);
 log('[Transformer.js] env.allowLocalModels: ' + transformers.env.allowLocalModels);
-if (transformers.env.allowLocalModels)
-{
+if (transformers.env.allowLocalModels) {
   transformers.env.localModelPath = "./models/";
   log('[Transformer.js] env.localModelPath: ' + transformers.env.localModelPath);
 }
@@ -138,49 +137,82 @@ const main = async () => {
     log(
       `[Transformer.js] Loading ${modelPath} and running image-classification pipeline`
     );
-    const classifier = await transformers.pipeline(
-      "image-classification",
-      modelPath,
-      options
-    );
-    let [err, output] = await asyncErrorHandling(
-      classifier(imageUrl, { topk: 3 })
-    );
-    if (err) {
-      status.setAttribute("class", "red");
-      info.innerHTML = err.message;
-      logError(err.message);
-    } else {
-      if (getMode()) {
-        log(JSON.stringify(transformers.getPerf()));
-        let warmUp = transformers.getPerf().warmup;
-        let averageInference = getAverage(transformers.getPerf().inference);
-        let medianInference = getMedian(transformers.getPerf().inference);
-        latency.innerHTML = medianInference.toFixed(2);
-        first.innerHTML = warmUp.toFixed(2);
-        average.innerHTML = averageInference;
-        median.innerHTML = medianInference.toFixed(2);
-        best.innerHTML = getMinimum(transformers.getPerf().inference);
-        throughput.innerHTML = `${transformers.getPerf().throughput} FPS`;
-        fullResult.setAttribute("class", "");
-        latencyDiv.setAttribute("class", "latency");
-      }
 
-      label1.innerHTML = output[0].label;
-      score1.innerText = output[0].score;
-      label2.innerText = output[1].label;
-      score2.innerText = output[1].score;
-      label3.innerText = output[2].label;
-      score3.innerText = output[2].score;
-      result.setAttribute("class", "");
-      label_uploadImage.setAttribute("class", "");
-      uploadImage.disabled = false;
-      classify.disabled = false;
-      log(JSON.stringify(output));
-      log(`[Transformer.js] Classifier completed`);
-    }
+    // let classifier;
+
+    // classifier = await transformers.pipeline(
+    //   "image-classification",
+    //   modelPath,
+    //   options
+    // );
+
+    // transformers.pipeline("image-classification", modelPath, options).then((res) => {
+    //   classifier = res;
+    // });
+
+    return new Promise((resolve, reject) => {
+      transformers.pipeline("image-classification", modelPath, options).then((res) => {
+        console.log("res", res);
+        resolve(res);
+      }).catch((err) => {
+        reject(err);
+      });
+    })
+
+
+    // console.log("classifier", classifier);
+    // let [err, output] = await asyncErrorHandling(
+    //   classifier(imageUrl, { topk: 3 })
+    // );
+    // console.log("output", output);
+    // console.log("err", err);
+    // if (err) {
+    //   status.setAttribute("class", "red");
+    //   info.innerHTML = err.message;
+    //   logError(err.message);
+    // } else {
+    //   if (getMode()) {
+    //     log(JSON.stringify(transformers.getPerf()));
+    //     let warmUp = transformers.getPerf().warmup;
+    //     let averageInference = getAverage(transformers.getPerf().inference);
+    //     let medianInference = getMedian(transformers.getPerf().inference);
+    //     latency.innerHTML = medianInference.toFixed(2);
+    //     first.innerHTML = warmUp.toFixed(2);
+    //     average.innerHTML = averageInference;
+    //     median.innerHTML = medianInference.toFixed(2);
+    //     best.innerHTML = getMinimum(transformers.getPerf().inference);
+    //     throughput.innerHTML = `${transformers.getPerf().throughput} FPS`;
+    //     fullResult.setAttribute("class", "");
+    //     latencyDiv.setAttribute("class", "latency");
+    //   }
+
+    //   label1.innerHTML = output[0].label;
+    //   score1.innerText = output[0].score;
+    //   label2.innerText = output[1].label;
+    //   score2.innerText = output[1].score;
+    //   label3.innerText = output[2].label;
+    //   score3.innerText = output[2].score;
+    //   result.setAttribute("class", "");
+    //   label_uploadImage.setAttribute("class", "");
+    //   uploadImage.disabled = false;
+    //   classify.disabled = false;
+    //   log(JSON.stringify(output));
+    //   log(`[Transformer.js] Classifier completed`);
+    // }
   } catch (err) {
     log(`[Error] ${err}`);
+
+    status.setAttribute("class", "red");
+    info.innerHTML = `
+            ${error}<br>
+            Your device probably doesn't have a supported GPU.`;
+    label_uploadImage.setAttribute("class", "disabled");
+    uploadImage.disabled = true;
+    classify.disabled = true;
+    log(`[Error] ${error}`);
+    log(
+      `[Error] Your device probably doesn't have a supported GPU`
+    );
   }
 };
 

--- a/demos/image-classification/index.js
+++ b/demos/image-classification/index.js
@@ -138,67 +138,49 @@ const main = async () => {
       `[Transformer.js] Loading ${modelPath} and running image-classification pipeline`
     );
 
-    // let classifier;
+    const classifier = await transformers.pipeline(
+      "image-classification",
+      modelPath,
+      options
+    );
 
-    // classifier = await transformers.pipeline(
-    //   "image-classification",
-    //   modelPath,
-    //   options
-    // );
+    let [err, output] = await asyncErrorHandling(
+      classifier(imageUrl, { topk: 3 })
+    );
 
-    // transformers.pipeline("image-classification", modelPath, options).then((res) => {
-    //   classifier = res;
-    // });
+    if (err) {
+      status.setAttribute("class", "red");
+      info.innerHTML = err.message;
+      logError(err.message);
+    } else {
+      if (getMode()) {
+        log(JSON.stringify(transformers.getPerf()));
+        let warmUp = transformers.getPerf().warmup;
+        let averageInference = getAverage(transformers.getPerf().inference);
+        let medianInference = getMedian(transformers.getPerf().inference);
+        latency.innerHTML = medianInference.toFixed(2);
+        first.innerHTML = warmUp.toFixed(2);
+        average.innerHTML = averageInference;
+        median.innerHTML = medianInference.toFixed(2);
+        best.innerHTML = getMinimum(transformers.getPerf().inference);
+        throughput.innerHTML = `${transformers.getPerf().throughput} FPS`;
+        fullResult.setAttribute("class", "");
+        latencyDiv.setAttribute("class", "latency");
+      }
 
-    return new Promise((resolve, reject) => {
-      transformers.pipeline("image-classification", modelPath, options).then((res) => {
-        console.log("res", res);
-        resolve(res);
-      }).catch((err) => {
-        reject(err);
-      });
-    })
-
-
-    // console.log("classifier", classifier);
-    // let [err, output] = await asyncErrorHandling(
-    //   classifier(imageUrl, { topk: 3 })
-    // );
-    // console.log("output", output);
-    // console.log("err", err);
-    // if (err) {
-    //   status.setAttribute("class", "red");
-    //   info.innerHTML = err.message;
-    //   logError(err.message);
-    // } else {
-    //   if (getMode()) {
-    //     log(JSON.stringify(transformers.getPerf()));
-    //     let warmUp = transformers.getPerf().warmup;
-    //     let averageInference = getAverage(transformers.getPerf().inference);
-    //     let medianInference = getMedian(transformers.getPerf().inference);
-    //     latency.innerHTML = medianInference.toFixed(2);
-    //     first.innerHTML = warmUp.toFixed(2);
-    //     average.innerHTML = averageInference;
-    //     median.innerHTML = medianInference.toFixed(2);
-    //     best.innerHTML = getMinimum(transformers.getPerf().inference);
-    //     throughput.innerHTML = `${transformers.getPerf().throughput} FPS`;
-    //     fullResult.setAttribute("class", "");
-    //     latencyDiv.setAttribute("class", "latency");
-    //   }
-
-    //   label1.innerHTML = output[0].label;
-    //   score1.innerText = output[0].score;
-    //   label2.innerText = output[1].label;
-    //   score2.innerText = output[1].score;
-    //   label3.innerText = output[2].label;
-    //   score3.innerText = output[2].score;
-    //   result.setAttribute("class", "");
-    //   label_uploadImage.setAttribute("class", "");
-    //   uploadImage.disabled = false;
-    //   classify.disabled = false;
-    //   log(JSON.stringify(output));
-    //   log(`[Transformer.js] Classifier completed`);
-    // }
+      label1.innerHTML = output[0].label;
+      score1.innerText = output[0].score;
+      label2.innerText = output[1].label;
+      score2.innerText = output[1].score;
+      label3.innerText = output[2].label;
+      score3.innerText = output[2].score;
+      result.setAttribute("class", "");
+      label_uploadImage.setAttribute("class", "");
+      uploadImage.disabled = false;
+      classify.disabled = false;
+      log(JSON.stringify(output));
+      log(`[Transformer.js] Classifier completed`);
+    }
   } catch (err) {
     log(`[Error] ${err}`);
 


### PR DESCRIPTION
**Problem**: Transformers.js currently thinks float16 is unsupported for other ML accelerators due to checking the *GPU* capability, but this isn't really correct because it's an unrelated device, and a workstation may not have a GPU, or the GPU may be disabled.

- Always return true from the fp16 check for now
- Add new error message as this check could cause an error on deny-listed GPUs

Note: I am not fully happy with the error handling here. Transformers.js seems to swallow errors in way that means we can't handle this specific error very well in our code. However, I want to do that as a separate PR as to not slow things down.