### PR TITLE
Update Safety Checker model for reduceSum with int32 input for Stable Diffusion 1.5

### DIFF
--- a/demos/stable-diffusion-1.5/index.js
+++ b/demos/stable-diffusion-1.5/index.js
@@ -719,7 +719,7 @@ async function loadModel(modelName /*:String*/, executionProvider /*:String*/) {
     //  Outputs:
     //    float16 out_images
     //    bool has_nsfw_concepts
-    modelPath = Utils.modelPath() + "safety-checker.onnx";
+    modelPath = Utils.modelPath() + "safety_checker_int32_reduceSum.onnx";
     freeDimensionOverrides = {
       batch: 1,
       channels: 3,


### PR DESCRIPTION
We updated Safety Checker model for reduceSum with int32 input for SD Turbo in https://github.com/microsoft/webnn-developer-preview/pull/11, but forgot to update the model for Stable Diffusion 1.5. @philloooo reported the issue.

@Adele101 Could you please help to copy [safety_checker_int32_reduceSum.onnx](https://huggingface.co/microsoft/sd-turbo-webnn/blob/main/safety_checker/safety_checker_int32_reduceSum.onnx) of https://huggingface.co/microsoft/sd-turbo-webnn/tree/main/safety_checker and upload it with same file name into https://huggingface.co/microsoft/stable-diffusion-v1.5-webnn/tree/main , thanks!

@fdwr Please help to review and merge this PR when @Adele101 uploaded the int32 SC model for Stable Diffusion 1.5. Thanks!

