### PR TITLE
Revert "Update Safety Checker model for reduceSum with int32 input for Stable Diffusion 1.5"

### DIFF
--- a/demos/stable-diffusion-1.5/index.js
+++ b/demos/stable-diffusion-1.5/index.js
@@ -719,7 +719,7 @@ async function loadModel(modelName /*:String*/, executionProvider /*:String*/) {
     //  Outputs:
     //    float16 out_images
     //    bool has_nsfw_concepts
-    modelPath = Utils.modelPath() + "safety_checker_int32_reduceSum.onnx";
+    modelPath = Utils.modelPath() + "safety-checker.onnx";
     freeDimensionOverrides = {
       batch: 1,
       channels: 3,


### PR DESCRIPTION
I'm reverting microsoft/webnn-developer-preview#24 for now until this CR finishes https://huggingface.co/microsoft/stable-diffusion-v1.5-webnn/discussions/1, because otherwise it breaks the sample:

![image](https://github.com/user-attachments/assets/bf3fb00b-4686-4b60-893c-e0f529c5e77b)

Will reapply right after the new model is in.