### PR TITLE
Update version of ONNX Runtime Web dists

### DIFF
--- a/assets/js/common_utils.js
+++ b/assets/js/common_utils.js
@@ -118,7 +118,7 @@ const ORT_BASE_URL = 'https://www.npmjs.com/package/onnxruntime-web/v/';
 const ORT_CDN_URL = 'https://cdn.jsdelivr.net/npm/onnxruntime-web@';
 const ortLink = (version) => `${ORT_BASE_URL}${version}?activeTab=versions`;
 
-const loadOrtScript = async (version, url) => {
+const loadScriptWithMessage = async (version, url) => {
   try {
     await loadScript('onnxruntime-web', url);
     return `ONNX Runtime Web: <a href="${ortLink(version)}">${version}</a>`;
@@ -134,13 +134,13 @@ export const setupORT = async () => {
   const queryOrt = getQueryValue('ort')?.toLowerCase();
   let versionHtml;
   if (queryOrt?.includes('-dev.')) {
-    versionHtml = await loadOrtScript(queryOrt, `${ORT_CDN_URL}${queryOrt}/dist/ort.all.min.js`);
+    versionHtml = await loadScriptWithMessage(queryOrt, `${ORT_CDN_URL}${queryOrt}/dist/ort.all.min.js`);
   } else if (queryOrt === 'test') {
     await loadScript('onnxruntime-web', '../../assets/dist/ort.all.min.js');
     versionHtml = 'ONNX Runtime Web: Test version';
   } else {
     const latestVersion = await getLatestOrtWebDevVersion();
-    versionHtml = await loadOrtScript(latestVersion, `${ORT_CDN_URL}${latestVersion}/dist/ort.all.min.js`);
+    versionHtml = await loadScriptWithMessage(latestVersion, `${ORT_CDN_URL}${latestVersion}/dist/ort.all.min.js`);
   }
   ortVersionElement.innerHTML = versionHtml;
 };

--- a/demos/sd-turbo/index.html
+++ b/demos/sd-turbo/index.html
@@ -13,7 +13,7 @@
         window.AutoTokenizer = AutoTokenizer;
     </script>
     <!-- <script src="ort-web/js/web/dist/ort.all.js"></script> -->
-    <script src="index.js"></script>
+    <script src="index.js" type="module"></script>
 </head>
 
 <body>

--- a/demos/sd-turbo/index.js
+++ b/demos/sd-turbo/index.js
@@ -153,7 +153,7 @@ async function readResponse(name, response) {
     if (done) return;
 
     let newLoaded = loaded + value.length;
-    fetchProgress = (newLoaded / contentLength) * 100;
+    let fetchProgress = (newLoaded / contentLength) * 100;
 
     if(!getSafetyChecker()) {
       if (name == "sd_turbo_text_encoder") {

--- a/demos/sd-turbo/index.js
+++ b/demos/sd-turbo/index.js
@@ -4,6 +4,8 @@
 // An example how to run sd-turbo with webnn in onnxruntime-web.
 //
 
+import { setupORT } from '../../assets/js/common_utils.js';
+
 const log = (i) => {
   console.log(i);
   if(getMode()) {
@@ -37,6 +39,7 @@ function getConfig() {
     device: "gpu",
     threads: "1",
     images: "4",
+    ort: "test"
   };
   let vars = query.split("&");
   for (var i = 0; i < vars.length; i++) {
@@ -907,32 +910,6 @@ const getTime = () => {
   return `${hour}:${min}:${sec}`;
 };
 
-const getDateTime = () => {
-  let date = new Date(),
-    m = padNumber(date.getMonth() + 1, 2),
-    d = padNumber(date.getDate(), 2),
-    hour = padNumber(date.getHours(), 2),
-    min = padNumber(date.getMinutes(), 2),
-    sec = padNumber(date.getSeconds(), 2);
-  return `${m}/${d} ${hour}:${min}:${sec}`;
-};
-
-const getOrtDevVersion = async () => {
-  const response = await fetch(
-    "https://cdn.jsdelivr.net/npm/onnxruntime-web/dist/"
-  );
-  const htmlString = await response.text();
-  const parser = new DOMParser();
-  const doc = parser.parseFromString(htmlString, "text/html");
-  let selectElement = doc.querySelector(".path li");
-  selectElement = doc.querySelector("select.versions.select-css");
-  let options = Array.from(selectElement.querySelectorAll("option")).map(
-    (option) => option.value
-  );
-  options = options.filter((option) => !option.includes("esmtest"));
-  return options[0].replace("onnxruntime-web@", "");
-};
-
 const checkWebNN = async () => {
   let status = document.querySelector("#webnnstatus");
   let info = document.querySelector("#info");
@@ -989,34 +966,6 @@ const webNnStatus = async () => {
     result.webnn = false;
     result.error = ex.message;
     return result;
-  }
-};
-
-const setupORT = async () => {
-  const ortversion = document.querySelector("#ortversion");
-  removeElement("onnxruntime-web");
-  await loadScript("onnxruntime-web", "../../assets/dist/ort.all.min.js");
-  ortversion.innerHTML = `ONNX Runtime Web: Test version`;
-};
-
-const loadScript = async (id, url) => {
-  return new Promise((resolve, reject) => {
-    const script = document.createElement("script");
-    script.onload = resolve;
-    script.onerror = reject;
-    script.id = id;
-    script.src = url;
-    if (url.startsWith("http")) {
-      script.crossOrigin = "anonymous";
-    }
-    document.body.append(script);
-  });
-};
-
-const removeElement = async (id) => {
-  let element = document.querySelector(id);
-  if (element) {
-    element.parentNode.removeChild(element);
   }
 };
 

--- a/demos/segment-anything/index.js
+++ b/demos/segment-anything/index.js
@@ -434,7 +434,7 @@ async function readResponse(name, response) {
     if (done) return;
 
     let newLoaded = loaded + value.length;
-    fetchProgress = (newLoaded / contentLength) * 100;
+    let fetchProgress = (newLoaded / contentLength) * 100;
 
     if (name.toLowerCase().indexOf("encoder") > -1) {
       samEncoderFetchProgress = 0.7 * fetchProgress;

--- a/demos/stable-diffusion-1.5/index.js
+++ b/demos/stable-diffusion-1.5/index.js
@@ -5,6 +5,7 @@
 //
 
 import * as Utils from "./utils.js";
+import { setupORT } from '../../assets/js/common_utils.js';
 
 // Configuration...
 const pixelWidth = 512;
@@ -209,13 +210,6 @@ function get_tensor_from_image(imageData, format) {
 
   return tensor;
 }
-
-const setupORT = async () => {
-  const ortversion = document.querySelector("#ortversion");
-  Utils.removeElement("onnxruntime-web");
-  await Utils.loadScript("onnxruntime-web", "../../assets/dist/ort.all.min.js");
-  ortversion.innerHTML = `ONNX Runtime Web: Test version`;
-};
 
 let progress = 0;
 let fetchProgress = 0;

--- a/demos/stable-diffusion-1.5/utils.js
+++ b/demos/stable-diffusion-1.5/utils.js
@@ -233,27 +233,6 @@ export function encodeFloat16(floatValue) /*: uint16 Number*/ {
   return bits;
 }
 
-export const loadScript = async (id, url) => {
-  return new Promise((resolve, reject) => {
-    const script = document.createElement("script");
-    script.onload = resolve;
-    script.onerror = reject;
-    script.id = id;
-    script.src = url;
-    if (url.startsWith("http")) {
-      script.crossOrigin = "anonymous";
-    }
-    document.body.append(script);
-  });
-};
-
-export const removeElement = async (id) => {
-  let element = document.querySelector(id);
-  if (element) {
-    element.parentNode.removeChild(element);
-  }
-};
-
 export const getQueryValue = (name) => {
   const urlParams = new URLSearchParams(window.location.search);
   return urlParams.get(name);
@@ -291,16 +270,6 @@ export const randomNumber = () => {
 const padNumber = (num, fill) => {
   let len = ("" + num).length;
   return Array(fill > len ? fill - len + 1 || 0 : 0).join(0) + num;
-};
-
-const getDateTime = () => {
-  let date = new Date(),
-    m = padNumber(date.getMonth() + 1, 2),
-    d = padNumber(date.getDate(), 2),
-    hour = padNumber(date.getHours(), 2),
-    min = padNumber(date.getMinutes(), 2),
-    sec = padNumber(date.getSeconds(), 2);
-  return `${m}/${d} ${hour}:${min}:${sec}`;
 };
 
 export const getTime = () => {

--- a/demos/whisper-base/main.js
+++ b/demos/whisper-base/main.js
@@ -5,7 +5,8 @@
 //
 
 import { Whisper } from "./whisper.js";
-import { loadScript, removeElement, getQueryValue, webNnStatus, log, logError, concatBuffer, concatBufferArray, logUser, getMode } from "./utils.js";
+import { getQueryValue, webNnStatus, log, logError, concatBuffer, concatBufferArray, logUser, getMode } from "./utils.js";
+import { setupORT } from '../../assets/js/common_utils.js';
 import VADBuilder, { VADMode, VADEvent } from "./vad/embedded.js";
 import AudioMotionAnalyzer from './static/js/audioMotion-analyzer.js?min';
 import { lcm } from "./vad/math.js";
@@ -579,21 +580,6 @@ async function processAudioBuffer() {
 
   if (lastSpeechCompleted && speechState == SpeechStates.PAUSED) {
     ready();
-  }
-}
-
-const setupORT = async () => {
-  const ortversion = document.querySelector('#ortversion');
-  removeElement('onnxruntime-web');
-  let ortVersion = "1.18.0";
-  let ortLink = '';
-  if (ortVersion && ortVersion.length > 4) {
-      await loadScript('onnxruntime-web', `https://cdn.jsdelivr.net/npm/onnxruntime-web@${ortVersion}/dist/ort.all.min.js`);
-      ortLink = `https://www.npmjs.com/package/onnxruntime-web/v/${ortVersion}`
-      ortversion.innerHTML = `ONNX Runtime Web: <a href="${ortLink}">${ortVersion}</a>`;
-  } else {
-      await loadScript('onnxruntime-web', '../../assets/dist/ort.all.min.js');
-      ortversion.innerHTML = `ONNX Runtime Web: Test version`;
   }
 }
 

--- a/demos/whisper-base/utils.js
+++ b/demos/whisper-base/utils.js
@@ -1,24 +1,3 @@
-export const loadScript = async (id, url) => {
-  return new Promise((resolve, reject) => {
-    const script = document.createElement("script");
-    script.onload = resolve;
-    script.onerror = reject;
-    script.id = id;
-    script.src = url;
-    if (url.startsWith("http")) {
-      script.crossOrigin = "anonymous";
-    }
-    document.body.append(script);
-  });
-};
-
-export const removeElement = async (id) => {
-  let el = document.querySelector(id);
-  if (el) {
-    el.parentNode.removeChild(el);
-  }
-};
-
 export const sleep = (ms) => {
   return new Promise((resolve) => setTimeout(resolve, ms));
 };
@@ -50,38 +29,12 @@ const padNumber = (num, fill) => {
   return Array(fill > len ? fill - len + 1 || 0 : 0).join(0) + num;
 };
 
-const getDateTime = () => {
-  let date = new Date(),
-    m = padNumber(date.getMonth() + 1, 2),
-    d = padNumber(date.getDate(), 2),
-    hour = padNumber(date.getHours(), 2),
-    min = padNumber(date.getMinutes(), 2),
-    sec = padNumber(date.getSeconds(), 2);
-  return `${m}/${d} ${hour}:${min}:${sec}`;
-};
-
 const getTime = () => {
   let date = new Date(),
     hour = padNumber(date.getHours(), 2),
     min = padNumber(date.getMinutes(), 2),
     sec = padNumber(date.getSeconds(), 2);
   return `${hour}:${min}:${sec}`;
-};
-
-export const getOrtDevVersion = async () => {
-  const response = await fetch(
-    "https://cdn.jsdelivr.net/npm/onnxruntime-web/dist/"
-  );
-  const htmlString = await response.text();
-  const parser = new DOMParser();
-  const doc = parser.parseFromString(htmlString, "text/html");
-  let selectElement = doc.querySelector(".path li");
-  selectElement = doc.querySelector("select.versions.select-css");
-  let options = Array.from(selectElement.querySelectorAll("option")).map(
-    (option) => option.value
-  );
-  options = options.filter((option) => !option.includes("esmtest"));
-  return options[0].replace("onnxruntime-web@", "");
 };
 
 export const webNnStatus = async () => {


### PR DESCRIPTION
Got an error report that `failed to execute 'gelu' on 'MLGraphBuilder': 1 argument required, but only 0 present` when running Whisper Base demo by using ONNX Runtime Web stable version 1.18.0, so update version of ONNX Runtime Web dists for SD 1.5, SD Turbo and Whisper Base with following changes (SA will continue to use internal test version due to einsum):

- Get latest dev version of ONNX Runtime Web by default
- "ort" parameter in URL, WebNN demo, ORT Web and Chromium implementation developers can use following url parameter to change the version of ONNX Runtime Web
  - No ort="" parameter // get latest dev version of ONNX Runtime Web dists
  - ort=1.20.0-dev.20240810-6ae7e02d34 // Specify exact dev version from https://www.npmjs.com/package/onnxruntime-web?activeTab=versions
  - ort=test // Internal WebNN EP of ORT Web dists, usually including the patches which are not included in latest dev version

@Honry PTAL before sending to Dwayne for the review.
