### PR TITLE
Revert "Revert Update Safety Checker model for reduceSum with int32 input for Stable Diffusion 1.5

### DIFF
--- a/demos/stable-diffusion-1.5/index.js
+++ b/demos/stable-diffusion-1.5/index.js
@@ -719,7 +719,7 @@ async function loadModel(modelName /*:String*/, executionProvider /*:String*/) {
     //  Outputs:
     //    float16 out_images
     //    bool has_nsfw_concepts
-    modelPath = Utils.modelPath() + "safety-checker.onnx";
+    modelPath = Utils.modelPath() + "safety_checker_int32_reduceSum.onnx";
     freeDimensionOverrides = {
       batch: 1,
       channels: 3,


### PR DESCRIPTION
For the SD 1.5 sample https://microsoft.github.io/webnn-developer-preview/demos/stable-diffusion-1.5/, restore the int32 safety checker model path, now that `safety_checker_int32_reduceSum.onnx` is uploaded to https://huggingface.co/microsoft/stable-diffusion-v1.5-webnn/discussions/1.

FYI @ibelem.