### PR TITLE
Add known compatible Chromium version for demos

### DIFF
--- a/assets/js/common_utils.js
+++ b/assets/js/common_utils.js
@@ -6,12 +6,10 @@ const KNOWN_COMPATIBLE_CHROMIUM_VERSION = {
   'image-classification': '129.0.6617.0'
 }
 
-export const showCompatibleChromiumVersion = () => {
-  const path = location.pathname.toLowerCase();
-  const matchingEntry = Object.entries(KNOWN_COMPATIBLE_CHROMIUM_VERSION).find(([key]) => path.includes(key));
-  if (matchingEntry) {
+export const showCompatibleChromiumVersion = (key) => {
+  const version = KNOWN_COMPATIBLE_CHROMIUM_VERSION[key]
+  if (version) {
     const chromiumVersionElement = document.querySelector('#chromiumversion');
-    const [key, version] = matchingEntry;
     chromiumVersionElement.innerHTML = `Known compatible Chromium version: 
       <a href="https://github.com/microsoft/webnn-developer-preview#breaking-changes" title="Known compatible Chromium version">
         ${version} 

--- a/assets/js/common_utils.js
+++ b/assets/js/common_utils.js
@@ -1,3 +1,31 @@
+const KNOWN_COMPATIBLE_CHROMIUM_VERSION = {
+  'stable-diffusion-1.5': '129.0.6617.0',
+  'sd-turbo': '129.0.6617.0',
+  'segment-anything': '129.0.6617.0',
+  'whisper-base': '129.0.6617.0',
+  'image-classification': '129.0.6617.0'
+}
+
+export const showCompatibleChromiumVersion = () => {
+  const path = location.pathname.toLowerCase();
+  const matchingEntry = Object.entries(KNOWN_COMPATIBLE_CHROMIUM_VERSION).find(([key]) => path.includes(key));
+  if (matchingEntry) {
+    const chromiumVersionElement = document.querySelector('#chromiumversion');
+    const [key, version] = matchingEntry;
+    chromiumVersionElement.innerHTML = `Known compatible Chromium version: 
+      <a href="https://github.com/microsoft/webnn-developer-preview#breaking-changes" title="Known compatible Chromium version">
+        ${version} 
+        <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#5f6368">
+          <path d="M440-280h80v-240h-80v240Zm40-320q17 0 28.5-11.5T520-640q0-17-11.5-28.5T480-680q-17 0-28.5 11.5T440-640q0 
+            17 11.5 28.5T480-600Zm0 520q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 
+            0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-80q134 0 
+            227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Zm0-320Z"/>
+        </svg>
+      </a>
+    `;
+  }
+}
+
 export const loadScript = async (id, url) => {
   return new Promise((resolve, reject) => {
     const script = document.createElement("script");

--- a/demos/image-classification/index.html
+++ b/demos/image-classification/index.html
@@ -208,7 +208,10 @@
             <div id="webnnstatus">
                 <span id="circle"></span> <span id="info">WebNN</span> <span id="backends"></span>
             </div>
-            <div id="ortversion"></div>
+            <div id="versions">
+                <div id="chromiumversion"></div>
+                <div id="ortversion"></div>
+            </div>
         </div>
     </div>
 </body>

--- a/demos/image-classification/index.js
+++ b/demos/image-classification/index.js
@@ -17,6 +17,7 @@ import {
   getMinimum,
   asyncErrorHandling,
   getMode,
+  showCompatibleChromiumVersion
 } from "../../assets/js/common_utils.js";
 
 transformers.env.backends.onnx.wasm.proxy = false;
@@ -556,9 +557,10 @@ const ui = async () => {
   controls();
   updateUi();
   await setupORT();
+  showCompatibleChromiumVersion();
   const ortversion = document.querySelector("#ortversion");
   let transformersJswithOrtVersion = ortversion.innerHTML;
-  ortversion.innerHTML = `<a href="https://huggingface.co/docs/transformers.js/en/index">Transformer.js</a> · ${transformersJswithOrtVersion}`;
+  ortversion.innerHTML = `${transformersJswithOrtVersion} · <a href="https://huggingface.co/docs/transformers.js/en/index">Transformer.js</a>`;
 
   console.log(`${provider} ${deviceType} ${modelId} ${runs}`);
 

--- a/demos/image-classification/index.js
+++ b/demos/image-classification/index.js
@@ -557,7 +557,7 @@ const ui = async () => {
   controls();
   updateUi();
   await setupORT();
-  showCompatibleChromiumVersion();
+  showCompatibleChromiumVersion('image-classification');
   const ortversion = document.querySelector("#ortversion");
   let transformersJswithOrtVersion = ortversion.innerHTML;
   ortversion.innerHTML = `${transformersJswithOrtVersion} · <a href="https://huggingface.co/docs/transformers.js/en/index">Transformer.js</a>`;

--- a/demos/image-classification/static/main.css
+++ b/demos/image-classification/static/main.css
@@ -816,19 +816,30 @@ h4 {
   background-color: var(--bg);
 }
 
-#ortversion {
+#versions {
   font-size: 0.9rem;
+  display: block;
   text-align: right;
 }
 
-#ortversion a {
+#versions svg {
+  height: 16px;
+  width: 16px;
+  margin-bottom: -3px;
+}
+
+#versions a {
   color: var(--font);
   text-decoration: underline var(--border);
 }
 
-#ortversion a:hover {
+#versions a:hover {
   color: var(--green);
   text-decoration: underline;
+}
+
+#versions a:hover svg path {
+  fill: var(--green);
 }
 
 #webnnstatus a {

--- a/demos/sd-turbo/index.html
+++ b/demos/sd-turbo/index.html
@@ -281,7 +281,10 @@
             <div class="footerinfo">
                 <div id="status" class="log-output"></div>
                 <div id="webnnstatus"><span id="circle"></span> <span id="info">WebNN</span></div>
-                <div id="ortversion"></div>
+                <div id="versions">
+                    <div id="chromiumversion"></div>
+                    <div id="ortversion"></div>
+                </div>
             </div>
             <div id="data" class="footerinfo">
                 <table>

--- a/demos/sd-turbo/index.js
+++ b/demos/sd-turbo/index.js
@@ -1046,7 +1046,7 @@ const ui = async () => {
   }
 
   await setupORT();
-  showCompatibleChromiumVersion();
+  showCompatibleChromiumVersion('sd-turbo');
 
   if (
     getQueryValue("provider") &&

--- a/demos/sd-turbo/index.js
+++ b/demos/sd-turbo/index.js
@@ -4,7 +4,7 @@
 // An example how to run sd-turbo with webnn in onnxruntime-web.
 //
 
-import { setupORT } from '../../assets/js/common_utils.js';
+import { setupORT, showCompatibleChromiumVersion } from '../../assets/js/common_utils.js';
 
 const log = (i) => {
   console.log(i);
@@ -1046,6 +1046,7 @@ const ui = async () => {
   }
 
   await setupORT();
+  showCompatibleChromiumVersion();
 
   if (
     getQueryValue("provider") &&

--- a/demos/sd-turbo/static/main.css
+++ b/demos/sd-turbo/static/main.css
@@ -807,19 +807,30 @@ h1.title span {
   background-color: var(--bg);
 }
 
-#ortversion {
+#versions {
   font-size: 0.9rem;
+  display: block;
   text-align: right;
 }
 
-#ortversion a {
-  color: var(--font);
-  text-decoration: none;
+#versions svg {
+  height: 16px;
+  width: 16px;
+  margin-bottom: -3px;
 }
 
-#ortversion a:hover {
+#versions a {
+  color: var(--font);
+  text-decoration: underline var(--border);
+}
+
+#versions a:hover {
   color: var(--green);
   text-decoration: underline;
+}
+
+#versions a:hover svg path {
+  fill: var(--green);
 }
 
 #data {

--- a/demos/segment-anything/index.html
+++ b/demos/segment-anything/index.html
@@ -8,7 +8,7 @@
   <link rel="icon" type="image/png" sizes="32x32" href="./static/favicon/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="./static/favicon/favicon-16x16.png">
   <link rel="stylesheet" href="./static/main.css">
-  <script src="./index.js"></script>
+  <script src="./index.js" type="module"></script>
 </head>
 
 <body>
@@ -126,7 +126,10 @@
 
     <div class="footerinfo">
       <div id="webnnstatus"><span id="circle"></span> <span id="info">WebNN</span> <span id="backends"></span></div>
-      <div id="ortversion"></div>
+      <div id="versions">
+        <div id="chromiumversion"></div>
+        <div id="ortversion"></div>
+    </div>
     </div>
   </div>
 

--- a/demos/segment-anything/index.js
+++ b/demos/segment-anything/index.js
@@ -757,7 +757,7 @@ const ui = async () => {
 
   canvas.setAttribute("class", "none");
   await setupORT();
-  showCompatibleChromiumVersion();
+  showCompatibleChromiumVersion('segment-anything');
 
   // ort.env.wasm.wasmPaths = 'dist/';
   ort.env.wasm.numThreads = config.threads;

--- a/demos/segment-anything/index.js
+++ b/demos/segment-anything/index.js
@@ -4,6 +4,8 @@
 // An example how to run segment-anything with webnn in onnxruntime-web.
 //
 
+import { showCompatibleChromiumVersion } from "../../assets/js/common_utils.js";
+
 // the image size on canvas
 const MAX_WIDTH = 480;
 const MAX_HEIGHT = 480;
@@ -755,6 +757,7 @@ const ui = async () => {
 
   canvas.setAttribute("class", "none");
   await setupORT();
+  showCompatibleChromiumVersion();
 
   // ort.env.wasm.wasmPaths = 'dist/';
   ort.env.wasm.numThreads = config.threads;

--- a/demos/segment-anything/static/main.css
+++ b/demos/segment-anything/static/main.css
@@ -427,19 +427,30 @@ h1.title span {
   background-color: var(--bg);
 }
 
-#ortversion {
+#versions {
   font-size: 0.9rem;
+  display: block;
   text-align: right;
 }
 
-#ortversion a {
-  color: var(--font);
-  text-decoration: none;
+#versions svg {
+  height: 16px;
+  width: 16px;
+  margin-bottom: -3px;
 }
 
-#ortversion a:hover {
+#versions a {
+  color: var(--font);
+  text-decoration: underline var(--border);
+}
+
+#versions a:hover {
   color: var(--green);
   text-decoration: underline;
+}
+
+#versions a:hover svg path {
+  fill: var(--green);
 }
 
 #webnnstatus a {

--- a/demos/stable-diffusion-1.5/index.html
+++ b/demos/stable-diffusion-1.5/index.html
@@ -187,7 +187,10 @@
             </div>
             <div class="footerinfo">
                 <div id="webnnstatus"><span id="circle"></span> <span id="info">WebNN</span></div>
-                <div id="ortversion"></div>
+                <div id="versions">
+                    <div id="chromiumversion"></div>
+                    <div id="ortversion"></div>
+                </div>
             </div>
         </div>
         <div class="right">

--- a/demos/stable-diffusion-1.5/index.js
+++ b/demos/stable-diffusion-1.5/index.js
@@ -1473,7 +1473,7 @@ const checkWebNN = async () => {
 
 const ui = async () => {
   await setupORT();
-  showCompatibleChromiumVersion();
+  showCompatibleChromiumVersion('stable-diffusion-1.5');
   if (
     Utils.getQueryValue("provider") &&
     Utils.getQueryValue("provider").toLowerCase().indexOf("webgpu") > -1

--- a/demos/stable-diffusion-1.5/index.js
+++ b/demos/stable-diffusion-1.5/index.js
@@ -5,7 +5,7 @@
 //
 
 import * as Utils from "./utils.js";
-import { setupORT } from '../../assets/js/common_utils.js';
+import { setupORT, showCompatibleChromiumVersion } from '../../assets/js/common_utils.js';
 
 // Configuration...
 const pixelWidth = 512;
@@ -1473,6 +1473,7 @@ const checkWebNN = async () => {
 
 const ui = async () => {
   await setupORT();
+  showCompatibleChromiumVersion();
   if (
     Utils.getQueryValue("provider") &&
     Utils.getQueryValue("provider").toLowerCase().indexOf("webgpu") > -1

--- a/demos/stable-diffusion-1.5/static/main.css
+++ b/demos/stable-diffusion-1.5/static/main.css
@@ -669,19 +669,30 @@ h1.title span {
   background-color: var(--bg);
 }
 
-#ortversion {
+#versions {
   font-size: 0.9rem;
+  display: block;
   text-align: right;
 }
 
-#ortversion a {
-  color: var(--font);
-  text-decoration: none;
+#versions svg {
+  height: 16px;
+  width: 16px;
+  margin-bottom: -3px;
 }
 
-#ortversion a:hover {
+#versions a {
+  color: var(--font);
+  text-decoration: underline var(--border);
+}
+
+#versions a:hover {
   color: var(--green);
   text-decoration: underline;
+}
+
+#versions a:hover svg path {
+  fill: var(--green);
 }
 
 #data {

--- a/demos/whisper-base/index.html
+++ b/demos/whisper-base/index.html
@@ -184,7 +184,10 @@
             </div>
             <div class="footerinfo">
                 <div id="webnnstatus"><span id="circle"></span> <span id="info">WebNN</span></div>
-                <div id="ortversion"></div>
+                <div id="versions">
+                    <div id="chromiumversion"></div>
+                    <div id="ortversion"></div>
+                </div>
             </div>
         </div>
     </div>

--- a/demos/whisper-base/main.js
+++ b/demos/whisper-base/main.js
@@ -6,7 +6,7 @@
 
 import { Whisper } from "./whisper.js";
 import { getQueryValue, webNnStatus, log, logError, concatBuffer, concatBufferArray, logUser, getMode } from "./utils.js";
-import { setupORT } from '../../assets/js/common_utils.js';
+import { setupORT, showCompatibleChromiumVersion } from '../../assets/js/common_utils.js';
 import VADBuilder, { VADMode, VADEvent } from "./vad/embedded.js";
 import AudioMotionAnalyzer from './static/js/audioMotion-analyzer.js?min';
 import { lcm } from "./vad/math.js";
@@ -603,6 +603,7 @@ const main = async () => {
   // progress.parentNode.style.display = "none";
 
   await setupORT();
+  showCompatibleChromiumVersion();
   ort.env.wasm.numThreads = 1;
   ort.env.wasm.simd = true;
 

--- a/demos/whisper-base/main.js
+++ b/demos/whisper-base/main.js
@@ -603,7 +603,7 @@ const main = async () => {
   // progress.parentNode.style.display = "none";
 
   await setupORT();
-  showCompatibleChromiumVersion();
+  showCompatibleChromiumVersion('whisper-base');
   ort.env.wasm.numThreads = 1;
   ort.env.wasm.simd = true;
 

--- a/demos/whisper-base/static/main.css
+++ b/demos/whisper-base/static/main.css
@@ -921,18 +921,34 @@ button svg {
   color: var(--bg);
 }
 
-#ortversion {
+#versions {
+  font-size: 12px;
+  display: block;
   text-align: right;
 }
 
-#ortversion a {
+#versions svg {
+  height: 12px;
+  width: 12px;
+  margin-bottom: -2px;
+}
+
+#versions a {
   color: var(--main);
   text-decoration: none;
 }
 
-#ortversion a:hover {
+#versions a svg path {
+  fill: var(--main);
+}
+
+#versions a:hover {
   color: var(--green);
   text-decoration: underline;
+}
+
+#versions a:hover svg path {
+  fill: var(--green);
 }
 
 #webnnstatus a {


### PR DESCRIPTION
- Add known compatible Chromium version for demos
- Add link to https://github.com/microsoft/webnn-developer-preview#breaking-changes
- Assign distinct compatibility version numbers to demos to prevent future discrepancies in minimum supported versions

```
const KNOWN_COMPATIBLE_CHROMIUM_VERSION = {
  'stable-diffusion-1.5': '129.0.6617.0',
  'sd-turbo': '129.0.6617.0',
  'segment-anything': '129.0.6617.0',
  'whisper-base': '129.0.6617.0',
  'image-classification': '129.0.6617.0'
}
```

@fdwr @Adele101 PTAL

![Screenshot 2024-08-16 111133](https://github.com/user-attachments/assets/fa39a002-d2b1-49cd-9280-4f78fbe846ca)
![Screenshot 2024-08-16 111217](https://github.com/user-attachments/assets/74d041a3-03c4-480d-ab84-57d324998777)
