### PR TITLE
feat(): driver version utility

### DIFF
--- a/assets/js/common_utils.js
+++ b/assets/js/common_utils.js
@@ -4,7 +4,18 @@ const KNOWN_COMPATIBLE_CHROMIUM_VERSION = {
   'segment-anything': '129.0.6617.0',
   'whisper-base': '129.0.6617.0',
   'image-classification': '129.0.6617.0'
-}
+};
+
+const KNOWN_COMPATIBLE_DRIVER_VERSION = {
+  'whisper-base': {
+    'intel': '32.0.100.2688',
+    'qualcomm': '30.0.31.225'
+  },
+  'image-classification': {
+    'intel': '32.0.100.2688',
+    'qualcomm': '30.0.31.176'
+  }
+};
 
 export const showCompatibleChromiumVersion = (key) => {
   const version = KNOWN_COMPATIBLE_CHROMIUM_VERSION[key]
@@ -21,6 +32,27 @@ export const showCompatibleChromiumVersion = (key) => {
         </svg>
       </a>
     `;
+  }
+};
+
+export const showCompatibleDriverVersion = (key) => {
+  const versionInfo = KNOWN_COMPATIBLE_DRIVER_VERSION[key];
+  if (versionInfo) {
+    // versionInfo will contain both qc and intel driver info
+    const driverVersionElement = document.querySelector('#driverinfo');
+    driverVersionElement.innerHTML = `
+      Known compatible driver version:
+        <a href="https://github.com/microsoft/webnn-developer-preview#breaking-changes" title="Known compatible driver version">
+        <span>Qualcomm: ${versionInfo.qualcomm}</span>
+        <span>Intel: ${versionInfo.intel}<span>
+        <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="#5f6368">
+          <path d="M440-280h80v-240h-80v240Zm40-320q17 0 28.5-11.5T520-640q0-17-11.5-28.5T480-680q-17 0-28.5 11.5T440-640q0 
+            17 11.5 28.5T480-600Zm0 520q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 
+            0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-80q134 0 
+            227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Zm0-320Z"/>
+        </svg>
+      </a>
+    `
   }
 }
 

--- a/demos/image-classification/index.html
+++ b/demos/image-classification/index.html
@@ -210,6 +210,7 @@
             </div>
             <div id="versions">
                 <div id="chromiumversion"></div>
+                <div id="driverinfo"></div>
                 <div id="ortversion"></div>
             </div>
         </div>

--- a/demos/image-classification/index.js
+++ b/demos/image-classification/index.js
@@ -17,7 +17,8 @@ import {
   getMinimum,
   asyncErrorHandling,
   getMode,
-  showCompatibleChromiumVersion
+  showCompatibleChromiumVersion,
+  showCompatibleDriverVersion
 } from "../../assets/js/common_utils.js";
 
 transformers.env.backends.onnx.wasm.proxy = false;
@@ -558,6 +559,7 @@ const ui = async () => {
   updateUi();
   await setupORT();
   showCompatibleChromiumVersion('image-classification');
+  showCompatibleDriverVersion('image-classification');
   const ortversion = document.querySelector("#ortversion");
   let transformersJswithOrtVersion = ortversion.innerHTML;
   ortversion.innerHTML = `${transformersJswithOrtVersion} · <a href="https://huggingface.co/docs/transformers.js/en/index">Transformer.js</a>`;

--- a/demos/whisper-base/index.html
+++ b/demos/whisper-base/index.html
@@ -186,6 +186,7 @@
                 <div id="webnnstatus"><span id="circle"></span> <span id="info">WebNN</span></div>
                 <div id="versions">
                     <div id="chromiumversion"></div>
+                    <div id="driverinfo"></div>
                     <div id="ortversion"></div>
                 </div>
             </div>

--- a/demos/whisper-base/main.js
+++ b/demos/whisper-base/main.js
@@ -6,7 +6,7 @@
 
 import { Whisper } from "./whisper.js";
 import { getQueryValue, webNnStatus, log, logError, concatBuffer, concatBufferArray, logUser, getMode } from "./utils.js";
-import { setupORT, showCompatibleChromiumVersion } from '../../assets/js/common_utils.js';
+import { setupORT, showCompatibleChromiumVersion, showCompatibleDriverVersion } from '../../assets/js/common_utils.js';
 import VADBuilder, { VADMode, VADEvent } from "./vad/embedded.js";
 import AudioMotionAnalyzer from './static/js/audioMotion-analyzer.js?min';
 import { lcm } from "./vad/math.js";
@@ -604,6 +604,7 @@ const main = async () => {
 
   await setupORT();
   showCompatibleChromiumVersion('whisper-base');
+  showCompatibleDriverVersion('whisper-base');
   ort.env.wasm.numThreads = 1;
   ort.env.wasm.simd = true;
 


### PR DESCRIPTION
Following the existing patterns, I have added a driver info utility to the site. 

Things I am unsure of:
- Do stable diffusion and segment-anything have compatible driver versions? I couldn't find those in the table
- Is the layout for the driver info, specifically how Qualcomm and Intel are displayed next to each other ok? 