### PR TITLE
Support latest ORT Web dists via URL parameter

### DIFF
--- a/assets/js/common_utils.js
+++ b/assets/js/common_utils.js
@@ -132,21 +132,22 @@ const KNOWN_COMPATIBLE_ORT_VERSION = {
 
 const ORT_BASE_URL = 'https://www.npmjs.com/package/onnxruntime-web/v/';
 const ORT_CDN_URL = 'https://cdn.jsdelivr.net/npm/onnxruntime-web@';
+const ORT_CDN_DATA_URL = 'https://data.jsdelivr.com/v1/packages/npm/onnxruntime-web';
 const ortLink = (version) => `${ORT_BASE_URL}${version}?activeTab=versions`;
 
 // Get the latest dev version of ONNX Runtime Web dists
 const getLatestOrtWebDevVersion = async () => {
   try {
-    const response = await fetch('https://cdn.jsdelivr.net/npm/onnxruntime-web/dist/');
-    const htmlString = await response.text();
-    const parser = new DOMParser();
-    const doc = parser.parseFromString(htmlString, 'text/html');
-    let selectElement = doc.querySelector('select.versions.select-css');
-    let options = Array.from(selectElement.querySelectorAll('option')).map(
-      (option) => option.value
-    );
-    let filteredOptions = options.filter(item => item.includes('-dev.'));
-    return filteredOptions[0].replace('onnxruntime-web@', '');
+    const response = await fetch(ORT_CDN_DATA_URL);
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+    const data = await response.json();
+    if (data.tags && data.tags.dev) {
+      return data.tags.dev;
+    } else {
+      console.error("Latest dev version of ONNX Runtime Web not found in the response");
+    }
   } catch (error) {
     console.error('Error:', error.message);
   }

--- a/assets/js/common_utils.js
+++ b/assets/js/common_utils.js
@@ -134,12 +134,33 @@ const ORT_BASE_URL = 'https://www.npmjs.com/package/onnxruntime-web/v/';
 const ORT_CDN_URL = 'https://cdn.jsdelivr.net/npm/onnxruntime-web@';
 const ortLink = (version) => `${ORT_BASE_URL}${version}?activeTab=versions`;
 
+// Get the latest dev version of ONNX Runtime Web dists
+const getLatestOrtWebDevVersion = async () => {
+  try {
+    const response = await fetch('https://cdn.jsdelivr.net/npm/onnxruntime-web/dist/');
+    const htmlString = await response.text();
+    const parser = new DOMParser();
+    const doc = parser.parseFromString(htmlString, 'text/html');
+    let selectElement = doc.querySelector('select.versions.select-css');
+    let options = Array.from(selectElement.querySelectorAll('option')).map(
+      (option) => option.value
+    );
+    let filteredOptions = options.filter(item => item.includes('-dev.'));
+    return filteredOptions[0].replace('onnxruntime-web@', '');
+  } catch (error) {
+    console.error('Error:', error.message);
+  }
+};
+
 const loadScriptWithMessage = async (version) => {
   try {
     if (version === 'test') {
       await loadScript('onnxruntime-web', '../../assets/dist/ort.all.min.js');
       return 'ONNX Runtime Web: Test version';
     } else {
+      if (version === 'latest') {
+        version = await getLatestOrtWebDevVersion();
+      }
       await loadScript('onnxruntime-web', `${ORT_CDN_URL}${version}/dist/ort.all.min.js`);
       return `ONNX Runtime Web: <a href="${ortLink(version)}">${version}</a>`;
     }


### PR DESCRIPTION
Support latest ORT Web dists via URL parameter `ort=[version]` (for test automation or debug purpose easier):

- Demos load ONNX Runtime Web versions based on https://github.com/microsoft/webnn-developer-preview/blob/main/assets/js/common_utils.js#L125C1-L131C3 with following default values
  - Fixed dev version for Stable Diffusion 1.5, SD Turbo, and Whisper Base
  - Test version for Segment Anything
- User can change versions of ONNX Runtime Web dists for Stable Diffusion 1.5, SD Turbo, Segment Anything and Whisper Base by adding `?ort=[version]` or `&ort=[version]`, which will override the default version 
  - `ort=1.19.0` or `ort=1.20.0-dev.20240810-6ae7e02d34` // Specify exact stable or dev versions from [npmjs.com/package/onnxruntime-web?activeTab=versions](https://www.npmjs.com/package/onnxruntime-web?activeTab=versions)
  - `ort=test` // Internal WebNN EP of ORT Web dists, usually including the patches which are not included in latest dev version
  - `ort=latest` // Get latest dev version of ONNX Runtime Web @honry 

### Related PRs: 
- https://github.com/microsoft/webnn-developer-preview/pull/33 
- https://github.com/microsoft/webnn-developer-preview/pull/28 

@fdwr PTAL when you have time, thanks!
