### PR TITLE
Add steps for enabling Insider version of Edge for WebNN Dev Preview

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -43,8 +43,12 @@
   --grey-05: rgba(107, 114, 128, 0.5);
   --green: rgba(1, 212, 73, 1);
   --pink: rgba(255, 0, 129, 1);
+  --green-02: rgba(1, 212, 73, 0.2);
+  --pink-02: rgba(255, 0, 129, 0.2);
   --green-01: rgba(1, 212, 73, 0.1);
   --pink-01: rgba(255, 0, 129, 0.1);
+  --green-003: rgba(1, 212, 73, 0.03);
+  --pink-003: rgba(255, 0, 129, 0.03);
 }
 
 body {
@@ -76,6 +80,10 @@ body {
   align-self: center;
 }
 
+.banner-content.installation {
+  height: 10vh;
+}
+
 #banner h1 {
   font-size: max(48px, min(5vw, 68px));
   text-shadow: 1px 1px 3px rgba(0, 0, 0, 0.15);
@@ -87,7 +95,7 @@ body {
 }
 
 #install-guides {
-  margin: 0rem auto 5rem auto;
+  margin: 0rem auto;
   text-align: left;
   padding: 20px 40px;
 }
@@ -307,7 +315,9 @@ a:focus {
   padding: 0px 6px;
   border-radius: 3px;
   text-decoration: none;
-  background-color: var(--pink-01);
+  background-color: var(--pink-003);
+  border-bottom: 1px dashed var(--pink-02);
+  font-size: 0.9rem;
 }
 
 #install-guides a:hover {
@@ -315,16 +325,22 @@ a:focus {
   color: var(--white);
 }
 
-#install-guides ol li {
-    padding: 0 10px;
+#install-guides ol, #install-guides ul {
+  margin: 2px 0;
+}
+
+#install-guides ol li, #install-guides ul li {
+    padding: 2px 10px;
 }
 
 code {
   margin: 1px auto;
-  background-color: var(--green-01);
+  background-color: var(--green-003);
+  border-bottom: 1px dashed var(--green-02);
   display: inline-block;
   padding: 0px 6px;
   border-radius: 3px;
+  font-size: 0.9rem;
   font-family: "Courier New", Courier, monospace;
 }
 

--- a/install.html
+++ b/install.html
@@ -228,7 +228,7 @@
       <h3>Enabling Insider version of Edge for WebNN Dev Preview NPU</h3>
       To get started with WebNN NPU on DirectML compatible devices you will need:
       <ul>
-        <li>Window 11, version 24H2 or newer</li>
+        <li>Windows 11, version 24H2 or newer</li>
         <li>Insider version of Edge (exact instructions provided below)</li>
         <li>The latest driver from our WebNN NPU Partners:
           <ul>

--- a/install.html
+++ b/install.html
@@ -210,7 +210,23 @@
       <h2>WebNN Installation Guide</h2>
     </section>
     <div id='install-guides'>
-      To get started with WebNN on DirectML compatible devices you will need:
+      <h3>Enabling Insider version of Edge for WebNN Dev Preview GPU</h3>
+      WebNN Dev Preview GPU requires a compatible browser to run, and Windows* 11
+      v21H2 (DML 1.6.0) or higher:
+      <ol>
+        <li>Download the <a href="https://www.microsoft.com/en-us/edge/download/insider?form=MA13FJ">Microsoft Edge Canary or Dev</a> browser</li>
+        <li>To enable WebNN, in your browser address bar, enter
+          <code>about://flags</code>, and then press
+          <code>Enter</code>. An Experiments page opens
+        </li>
+        <li>In the Search flags box, enter <code>webnn</code>.
+          Enables WebNN API appears</li>
+        <li>In the drop-down menu, select <code>Enabled</code></li>
+        <li>Relaunch your browser</li>
+      </ol>
+
+      <h3>Enabling Insider version of Edge for WebNN Dev Preview NPU</h3>
+      To get started with WebNN NPU on DirectML compatible devices you will need:
       <ul>
         <li>Window 11, version 24H2 or newer</li>
         <li>Insider version of Edge (exact instructions provided below)</li>
@@ -221,7 +237,7 @@
           </ul>
         </li>
       </ul>
-      <h3>Enabling Insider version of Edge for WebNN Dev Preview</h3>
+      Enabling Insider version of Edge:
       <ol>
         <li>
           <a href="https://www.microsoft.com/en-us/edge/download/insider?form=MA13FJ">Microsoft Edge Canary or Dev Channel</a> with WebNN flag enabled in <code>about:flags</code>

--- a/install.html
+++ b/install.html
@@ -241,7 +241,7 @@
           </ol>
         </li>
         <li>
-          Copy <code>microsoft.ai.directml.1.15.2.nupkg.zip\bin\-win\directml.dll</code> to the appropriate directory<br>(replace with x64 on Intel devices and arm64 on Qualcomm devices)
+          Copy <code>microsoft.ai.directml.1.15.2.nupkg.zip\bin\&lt;arch&gt;-win\directml.dll</code> to the appropriate directory<br>(replace with x64 on Intel devices and arm64 on Qualcomm devices)
           <ol style="list-style: lower-alpha;">
             <li>Edge Dev: <code>C:\Program Files (x86)\Microsoft\Edge Dev\Application\129.0.2779.0\</code>
               <ol>

--- a/install.html
+++ b/install.html
@@ -206,25 +206,69 @@
         </svg>
       </a>
     </header>
-    <section class="banner-content" id="banner">
+    <section class="banner-content installation" id="banner">
       <h2>WebNN Installation Guide</h2>
     </section>
     <div id='install-guides'>
-      WebNN requires a compatible browser to run, and Windows* 11
-      v21H2 (DML 1.6.0) or higher.
-      <ol>
-        <li>Download the <a href="https://www.microsoft.com/edge/download/insider"
-            title="Microsoft Edge Dev channel version">Microsoft
-            Edge Dev channel version</a> or later
-          browser</li>
-        <li>To enable WebNN, in your browser address bar, enter
-          <code>about://flags</code>, and then press
-          <code>Enter</code>. An Experiments page opens
+      To get started with WebNN on DirectML compatible devices you will need:
+      <ul>
+        <li>Window 11, version 24H2 or newer</li>
+        <li>Insider version of Edge (exact instructions provided below)</li>
+        <li>The latest driver from our WebNN NPU Partners:
+          <ul>
+            <li><a href="https://www.intel.com/content/www/us/en/download/794734/intel-npu-driver-windows.html">Intel® Core™ Ultra NPU Driver for Windows</a></li>
+            <li><a href="https://qpm.qualcomm.com/#/main/tools/details/QHND">Qualcomm® Hexagon NPU Driver Package for windows</a></li>
+          </ul>
         </li>
-        <li>In the Search flags box, enter <code>webnn</code>.
-          Enables WebNN API appears</li>
-        <li>In the drop-down menu, select <code>Enabled</code></li>
-        <li>Relaunch your browser</li>
+      </ul>
+      <h3>Enabling Insider version of Edge for WebNN Dev Preview</h3>
+      <ol>
+        <li>
+          <a href="https://www.microsoft.com/en-us/edge/download/insider?form=MA13FJ">Microsoft Edge Canary or Dev Channel</a> with WebNN flag enabled in <code>about:flags</code>
+          <ol style="list-style: lower-alpha;">
+            <li>Download from <a href="https://www.microsoft.com/en-us/edge/download/insider">https://www.microsoft.com/en-us/edge/download/insider</a></li>
+            <li>Run installer</li>
+            <li>Navigate to <code>about://flags</code></li>
+            <li>Search for <code>Enables WebNN API</code> and change it to <code>Enabled</code></li>
+            <li>Exit browser</li>
+          </ol>
+        </li>
+        <li>
+          Download DirectML redistributable
+          <ol style="list-style: lower-alpha;">
+            <li>Download DirectML from <a href="https://www.nuget.org/packages/Microsoft.AI.DirectML/1.15.2">https://www.nuget.org/packages/Microsoft.AI.DirectML/1.15.2</a></li>
+            <li>Rename <code>microsoft.ai.directml.1.15.2.nupkg</code> to <code>microsoft.ai.directml.1.15.2.nupkg.zip</code> and extract it</li>
+          </ol>
+        </li>
+        <li>
+          Copy <code>microsoft.ai.directml.1.15.2.nupkg.zip\bin\-win\directml.dll</code> to the appropriate directory<br>(replace with x64 on Intel devices and arm64 on Qualcomm devices)
+          <ol style="list-style: lower-alpha;">
+            <li>Edge Dev: <code>C:\Program Files (x86)\Microsoft\Edge Dev\Application\129.0.2779.0\</code>
+              <ol>
+                <li>When the dialog asks for Administrator permission, choose <code>Continue</code></li>
+              </ol>
+            </li>
+            <li>Edge Canary: <code>%LOCALAPPDATA%\Microsoft\Edge SxS\Application\129.0.2779.0\</code></li>
+            <li>Note the following on copying <code>Directml.dll</code> to Edge directory
+              <ol>
+                <li>The version-specific directory (129.0.2779.0) may differ on your machine</li>
+                <li>New versions of Edge may require <code>directml.dll</code> to be recopied to the directory</li>
+              </ol>
+            </li>
+          </ol>
+        </li>
+        <li>
+          Launch Edge insider
+          <ol style="list-style: lower-alpha;">
+            <li>Open terminal and change your working directory to the Edge Insider build:
+              <ul>
+                <li>If using Edge Dev: <code>C:\Program Files (x86)\Microsoft\Edge Dev\Application</code></li>
+                <li>If using Edge Canary: <code>%LOCALAPPDATA%\Microsoft\Edge SxS\Application</code></li>
+              </ul>
+            </li>
+            <li><code>.\msedge.exe –use-redist-dml –disable_webnn_for_npu=0 –disable-gpu-sandbox</code></li>
+          </ol>
+        </li>
       </ol>
     </div>
   </section>


### PR DESCRIPTION
@fdwr @Adele101 PTAL 

Fully copied from https://blogs.windows.com/windowsdeveloper/2024/08/29/directml-expands-npu-support-to-copilot-pcs-and-webnn/

@mingmingtasd @huningxin

![127 0 0 1_8080_install html](https://github.com/user-attachments/assets/a35198e2-d452-4552-8872-406e1a4a0525)
