### PR TITLE
Fix typo of command line switch

### DIFF
--- a/install.html
+++ b/install.html
@@ -282,7 +282,7 @@
                 <li>If using Edge Canary: <code>%LOCALAPPDATA%\Microsoft\Edge SxS\Application</code></li>
               </ul>
             </li>
-            <li><code>.\msedge.exe –use-redist-dml –disable_webnn_for_npu=0 –disable-gpu-sandbox</code></li>
+            <li><code>.\msedge.exe --use-redist-dml --disable_webnn_for_npu=0 --disable-gpu-sandbox</code></li>
           </ol>
         </li>
       </ol>


### PR DESCRIPTION
There are typos in blog post https://blogs.windows.com/windowsdeveloper/2024/08/29/directml-expands-npu-support-to-copilot-pcs-and-webnn/ that –use-redist-dml should be --use-redist-dml (all double-hyphens were consolidated) . Didn't capture this issue when updated them into Dev Preview site.

@fdwr @Adele101 PTAL

