### PR TITLE
Support devicetype parameter for SD and SA demos

### DIFF
--- a/demos/sd-turbo/index.js
+++ b/demos/sd-turbo/index.js
@@ -36,7 +36,7 @@ function getConfig() {
     mode: "none",
     safetychecker: true,
     provider: "webnn",
-    device: "gpu",
+    devicetype: "gpu",
     threads: "1",
     images: "4",
     ort: "test"
@@ -222,6 +222,7 @@ const updateProgress = () => {
  */
 async function load_models(models) {
   log("[Load] ONNX Runtime Execution Provider: " + config.provider);
+  log("[Load] ONNX Runtime EP device type: " + config.devicetype);
   updateLoadWave(0.0);
   load.disabled = true;
 
@@ -1134,7 +1135,7 @@ const ui = async () => {
         opt.executionProviders = [
           {
             name: "webnn",
-            deviceType: config.device
+            deviceType: config.devicetype
           },
         ];
       }

--- a/demos/segment-anything/index.js
+++ b/demos/segment-anything/index.js
@@ -99,7 +99,7 @@ function getConfig() {
     mode: "none",  
     model: "sam_b",
     provider: "webnn",
-    device: "gpu",
+    devicetype: "gpu",
     threads: "1",
     ort: "test"
   };
@@ -487,6 +487,7 @@ const getMode = () => {
  */
 async function load_models(models) {
   log("[Load] ONNX Runtime Execution Provider: " + config.provider);
+  log("[Load] ONNX Runtime EP device type: " + config.devicetype);
 
   for (const [id, model] of Object.entries(models)) {
     let start;
@@ -513,7 +514,7 @@ async function load_models(models) {
         opt.executionProviders = [
           {
             name: "webnn",
-            deviceType: "gpu",
+            deviceType: config.devicetype,
           },
         ];
         opt.freeDimensionOverrides = {

--- a/demos/stable-diffusion-1.5/index.js
+++ b/demos/stable-diffusion-1.5/index.js
@@ -728,7 +728,7 @@ async function loadModel(modelName /*:String*/, executionProvider /*:String*/) {
     executionProviders: [
       {
         name: executionProvider,
-        deviceType: Utils.getQueryVariable("device", "gpu")
+        deviceType: Utils.getQueryVariable("devicetype", "gpu")
       },
     ],
   };
@@ -1440,6 +1440,7 @@ async function generateNextImage() {
 
 const executionProvider = Utils.getQueryVariable("provider", "webnn");
 Utils.log("[Load] Execution Provider: " + executionProvider);
+Utils.log("[Load] EP device type: " + Utils.getQueryVariable("devicetype", "gpu"));
 
 const checkWebNN = async () => {
   let status = document.querySelector("#webnnstatus");


### PR DESCRIPTION
Currently devicetype=npu and (and devicetype=cpu in URL) can work for image classification and whisper demos, but not correctly work for SD sand SA demos.

Changes:
- Support devicetype parameter for Stable Diffusion 1.5, SD Turbo and and Segment Anything demos
- No UI support for SD and SA demos for now (until enabling them on NPU)

Purpose:
- Test Chromium implementation status of devicetype=cpu and devicetype=npu 

@fdwr @Adele101 PTAL

CC @fujunwei @Honry 