### PR TITLE
Failed to read the shape property error

### DIFF
--- a/assets/js/common_utils.js
+++ b/assets/js/common_utils.js
@@ -123,11 +123,11 @@ export const getTime = () => {
 };
 
 const KNOWN_COMPATIBLE_ORT_VERSION = {
-  'stable-diffusion-1.5': { 'dev': '1.19.0-dev.20240804-ee2fe87e2d', 'stable': '1.20.0', 'test': 'test' },
-  'sd-turbo': { 'dev': '1.19.0-dev.20240804-ee2fe87e2d', 'stable': '1.20.0', 'test': 'test' },
-  'segment-anything': { 'dev': '1.19.0-dev.20240804-ee2fe87e2d', 'stable': '1.20.0', 'test': 'test' },
-  'whisper-base': { 'dev': '1.19.0-dev.20240804-ee2fe87e2d', 'stable': '1.20.0', 'test': 'test' },
-  'image-classification': { 'dev': '1.19.0-dev.20240804-ee2fe87e2d', 'stable': '1.20.0', 'test': 'test' },
+  'stable-diffusion-1.5': { 'dev': '1.20.0-dev.20240919-bd60add8ce', 'stable': '1.20.0', 'test': 'test' },
+  'sd-turbo': { 'dev': '1.20.0-dev.20240919-bd60add8ce', 'stable': '1.20.0', 'test': 'test' },
+  'segment-anything': { 'dev': '1.20.0-dev.20240919-bd60add8ce', 'stable': '1.20.0', 'test': 'test' },
+  'whisper-base': { 'dev': '1.20.0-dev.20240919-bd60add8ce', 'stable': '1.20.0', 'test': 'test' },
+  'image-classification': { 'dev': '1.20.0-dev.20240919-bd60add8ce', 'stable': '1.20.0', 'test': 'test' },
 };
 
 const ORT_BASE_URL = 'https://www.npmjs.com/package/onnxruntime-web/v/';


### PR DESCRIPTION
![image001](https://github.com/user-attachments/assets/ebae1d1f-d3fe-4e9c-8ddd-4574b1737f8a)

- PASS 1.20.0-dev.20241016-2b8fc5529b
- PASS 1.20.0-dev.20240928-1bda91fc57
- PASS 1.20.0-dev.20240925-a47254eaef
- PASS 1.20.0-dev.20240919-bd60add8ce
- FAIL 1.20.0-dev.20240917-afd642a194
- FAIL 1.20.0-dev.20240916-6d7235ba5a
- FAIL 1.19.0-dev.20240804-ee2fe87e2d

### Impacted demos:
- SD 1.5
- SD Turbo
- Whisper Base
- Image Classification

### Workaround before merging this PR:
- https://microsoft.github.io/webnn-developer-preview/demos/stable-diffusion-1.5/?ort=1.20.0-dev.20240919-bd60add8ce
- https://microsoft.github.io/webnn-developer-preview/demos/sd-turbo/?ort=1.20.0-dev.20240919-bd60add8ce
- https://microsoft.github.io/webnn-developer-preview/demos/whisper-base/?ort=1.20.0-dev.20240919-bd60add8ce

@fdwr PTAL

Please note that the image classification still doesn't work. I will build new transformers.js dist based on ort >= 1.20.0-dev.20240919-bd60add8ce after a meeting. 
