### PR TITLE
Whisper base - use same models for WebNN GPU and NPU

### DIFF
--- a/demos/whisper-base/whisper.js
+++ b/demos/whisper-base/whisper.js
@@ -112,11 +112,7 @@ export class Whisper {
             try {
                 let url = this.url + this.models[name]["url"];
                 if (this.dataType == "float16") {
-                    if (this.deviceType == "npu") {
-                        url = url.replace(".onnx", "_fp16_layernorm_gelu.onnx");
-                    } else {
-                        url = url.replace(".onnx", "_fp16_layernorm.onnx");
-                    }
+                    url = url.replace(".onnx", "_fp16_layernorm_gelu.onnx");
                     if (name.includes("decoder") && this.mask_4d) {
                         url = url.replace(".onnx", "_4dmask.onnx");
                     }

--- a/fetch_models.js
+++ b/fetch_models.js
@@ -72,34 +72,19 @@ const models = [
         path: "./demos/segment-anything/models",
     },
     {
-        url: "microsoft/whisper-base-webnn/resolve/main/whisper_base_decoder_static_kvcache_128_lm_fp16_layernorm_4dmask.onnx",
-        path: "./demos/whisper-base/models",
-        note: "Decoder model with 4dmask for WebNN GPU",
-    },
-    {
         url: "microsoft/whisper-base-webnn/resolve/main/whisper_base_decoder_static_kvcache_128_lm_fp16_layernorm_gelu_4dmask.onnx",
         path: "./demos/whisper-base/models",
-        note: "Gelu and 4dmask are used for decoder on WebNN NPU",
-    },
-    {
-        url: "microsoft/whisper-base-webnn/resolve/main/whisper_base_decoder_static_non_kvcache_lm_fp16_layernorm_4dmask.onnx",
-        path: "./demos/whisper-base/models",
-        note: "Decoder model with 4dmask for WebNN GPU",
+        note: "Gelu and 4dmask are used for decoder",
     },
     {
         url: "microsoft/whisper-base-webnn/resolve/main/whisper_base_decoder_static_non_kvcache_lm_fp16_layernorm_gelu_4dmask.onnx",
         path: "./demos/whisper-base/models",
-        note: "Gelu and 4dmask are used for decoder on WebNN NPU",
-    },
-    {
-        url: "microsoft/whisper-base-webnn/resolve/main/whisper_base_encoder_lm_fp16_layernorm.onnx",
-        path: "./demos/whisper-base/models",
-        note: "Encoder model for WebNN GPU",
+        note: "Gelu and 4dmask are used for decoder",
     },
     {
         url: "microsoft/whisper-base-webnn/resolve/main/whisper_base_encoder_lm_fp16_layernorm_gelu.onnx",
         path: "./demos/whisper-base/models",
-        note: "Gelu is used for encoder on WebNN NPU",
+        note: "Gelu is used for encoder",
     },
 ];
 

--- a/fetch_models.js
+++ b/fetch_models.js
@@ -74,12 +74,12 @@ const models = [
     {
         url: "microsoft/whisper-base-webnn/resolve/main/whisper_base_decoder_static_kvcache_128_lm_fp16_layernorm_gelu_4dmask.onnx",
         path: "./demos/whisper-base/models",
-        note: "Gelu and 4dmask are used for decoder",
+        note: "Gelu and 4D mask are used for decoder",
     },
     {
         url: "microsoft/whisper-base-webnn/resolve/main/whisper_base_decoder_static_non_kvcache_lm_fp16_layernorm_gelu_4dmask.onnx",
         path: "./demos/whisper-base/models",
-        note: "Gelu and 4dmask are used for decoder",
+        note: "Gelu and 4D mask are used for decoder",
     },
     {
         url: "microsoft/whisper-base-webnn/resolve/main/whisper_base_encoder_lm_fp16_layernorm_gelu.onnx",


### PR DESCRIPTION
Users/developers are confused by using two Whisper Base model sets for WebNN GPU and WebNN NPU, we can only use models that with `gelu` now to mitigate this issue.

@fdwr PTAL
