### PR TITLE
ORT dist - Use dispatch() for SD 1.5, SD Turbo and Whisper Base

### DIFF
--- a/assets/js/common_utils.js
+++ b/assets/js/common_utils.js
@@ -4,7 +4,7 @@ const KNOWN_COMPATIBLE_CHROMIUM_VERSION = {
     "segment-anything": "129.0.6617.0",
     "whisper-base": "129.0.6617.0",
     "image-classification": "129.0.6617.0",
-    "phi-3-mini": "132.0.6823.0",
+    "phi-3-mini": "132.0.6831.0",
 };
 
 export const showCompatibleChromiumVersion = key => {
@@ -119,33 +119,28 @@ export const getTime = () => {
 
 const KNOWN_COMPATIBLE_ORT_VERSION = {
     "stable-diffusion-1.5": {
-        dev: "1.20.0-dev.20240919-bd60add8ce",
-        stable: "1.20.0",
-        test: "test",
+        dev: "1.21.0-dev.20241109-d3ad76b2cf",
+        stable: "",
+        test: "",
     },
     "sd-turbo": {
-        dev: "1.20.0-dev.20240919-bd60add8ce",
-        stable: "1.20.0",
-        test: "test",
+        dev: "1.21.0-dev.20241109-d3ad76b2cf",
+        stable: "",
+        test: "",
     },
     "segment-anything": {
-        dev: "1.20.0-dev.20240919-bd60add8ce",
-        stable: "1.20.0",
+        dev: "",
+        stable: "",
         test: "test",
     },
     "whisper-base": {
-        dev: "1.20.0-dev.20240919-bd60add8ce",
-        stable: "1.20.0",
-        test: "test",
-    },
-    "image-classification": {
-        dev: "1.20.0-dev.20240919-bd60add8ce",
-        stable: "1.20.0",
-        test: "test",
+        dev: "1.21.0-dev.20241109-d3ad76b2cf",
+        stable: "",
+        test: "",
     },
     "phi-3-mini": {
-        dev: "1.20.0-dev.20240919-bd60add8ce",
-        stable: "1.20.0",
+        dev: "",
+        stable: "",
         test: "test",
     },
 };


### PR DESCRIPTION
> [compute()](https://www.w3.org/TR/webnn/#dom-mlcontext-compute) will be deprecated and removed in favor of [dispatch()](https://github.com/webmachinelearning/webnn/blob/main/mltensor-explainer.md#compute-vs-dispatch).

Update latest dev version of ORT dists which support dispatch() for SD 1.5, SD Turbo and Whisper Base demos.

- SD 1.5 / ORT 1.21.0-dev.20241109-d3ad76b2cf
- SD Turbo / ORT 1.21.0-dev.20241109-d3ad76b2cf
- Whisper Base / ORT 1.21.0-dev.20241109-d3ad76b2cf 
- Image Classification / Transformers.js dist built with ORT 1.21.0-dev.20241109-d3ad76b2cf
- Segment Anything / Test dists by using dispatch() in https://github.com/microsoft/webnn-developer-preview/pull/52/files#diff-9940e30cb48d0308e828926531652ef2298a6c43260f69c1ba58fee8ea255435
- Phi-3 Mini / Test dists by using dispatch() in https://github.com/microsoft/webnn-developer-preview/pull/52/files#diff-9940e30cb48d0308e828926531652ef2298a6c43260f69c1ba58fee8ea255435, will update to ORT dev version after merging https://github.com/microsoft/onnxruntime/pull/22795

@fdwr PTAL