### PR TITLE
Update README.md with breaking changes for MLTensorUsage

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ npm run fetch-models
 
 WebNN is a living specification and still subject to breaking changes, which may impact the samples depending on your browser version. The following are recent:
 
+-   2024-11-12 Remove grace-period support for MLTensorUsage - [spec change](https://github.com/webmachinelearning/webnn/pull/754), [Chromium change](https://chromium-review.googlesource.com/c/chromium/src/+/6015318)
 -   2024-10-29 Convert MLOperand methods into readonly attributes - [spec change](https://github.com/webmachinelearning/webnn/pull/774), [Chromium change](https://chromium-review.googlesource.com/c/chromium/src/+/5975719)
 -   2024-09-30 (pending breaking change) Replace MLContext.compute() with MLContext.dispatch() - [spec change](https://github.com/webmachinelearning/webnn/pull/754), [Chromium change](https://chromium-review.googlesource.com/c/chromium/src/+/5874589), [ORT change](https://github.com/microsoft/onnxruntime/pull/21301/), [sample change](https://github.com/webmachinelearning/webnn-samples/issues/275)
 -   2024-09-24 Make MLOperandDescriptor.shape a required dictionary member - [spec change](https://github.com/webmachinelearning/webnn/issues/758), [Chromium change](https://chromium-review.googlesource.com/c/chromium/src/+/5850659)


### PR DESCRIPTION
Causes "MLTensorUsage is not defined" on Chromium 133.0.6835.0.

https://github.com/microsoft/webnn-developer-preview/issues/57