### PR TITLE
Update README.md breaking change notices for Float16Array

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,12 @@ npm run fetch-models
 
 ### Breaking Changes
 
-WebNN is a living specification and still subject to breaking changes, which may impact the samples depending on your browser version. The following are recent:
+WebNN is a living specification and still subject to breaking changes, which may impact the samples depending on your browser version:
 
+- 2025-03-03 Enable Float16Array by default - spec change NA, [Chromium change](https://chromium-review.googlesource.com/c/chromium/src/+/6275531), [ORT change](https://github.com/microsoft/onnxruntime/pull/23827)
 -   2024-11-12 Remove grace-period support for MLTensorUsage - [spec change](https://github.com/webmachinelearning/webnn/pull/754), [Chromium change](https://chromium-review.googlesource.com/c/chromium/src/+/6015318)
 -   2024-10-29 Convert MLOperand methods into readonly attributes - [spec change](https://github.com/webmachinelearning/webnn/pull/774), [Chromium change](https://chromium-review.googlesource.com/c/chromium/src/+/5975719)
--   2024-09-30 (pending breaking change) Replace MLContext.compute() with MLContext.dispatch() - [spec change](https://github.com/webmachinelearning/webnn/pull/754), [Chromium change](https://chromium-review.googlesource.com/c/chromium/src/+/5874589), [ORT change](https://github.com/microsoft/onnxruntime/pull/21301/), [sample change](https://github.com/webmachinelearning/webnn-samples/issues/275)
+-   2024-09-30 Replace MLContext.compute() with MLContext.dispatch() - [spec change](https://github.com/webmachinelearning/webnn/pull/754), [Chromium change](https://chromium-review.googlesource.com/c/chromium/src/+/5874589), [ORT change](https://github.com/microsoft/onnxruntime/pull/21301/), [sample change](https://github.com/webmachinelearning/webnn-samples/issues/275)
 -   2024-09-24 Make MLOperandDescriptor.shape a required dictionary member - [spec change](https://github.com/webmachinelearning/webnn/issues/758), [Chromium change](https://chromium-review.googlesource.com/c/chromium/src/+/5850659)
 -   2024-09-17 Rename MLOperandDescriptor's "dimensions" key to "shape" - [spec change](https://github.com/webmachinelearning/webnn/pull/676), [Chromium change](https://chromium-review.googlesource.com/c/chromium/src/+/5502631), [Chromium change 2](https://chromium-review.googlesource.com/c/chromium/src/+/5502631)
 -   2024-07-24 `MLContextOptions::MLPowerPreference` rename `auto` to `default` - [Chromium change](https://chromium-review.googlesource.com/c/chromium/src/+/5716629)

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ npm run fetch-models
 
 WebNN is a living specification and still subject to breaking changes, which may impact the samples depending on your browser version:
 
-- 2025-03-03 Enable Float16Array by default - spec change NA, [Chromium change](https://chromium-review.googlesource.com/c/chromium/src/+/6275531), [ORT change](https://github.com/microsoft/onnxruntime/pull/23827)
+-   2025-03-03 Enable Float16Array by default - spec change NA, [Chromium change](https://chromium-review.googlesource.com/c/chromium/src/+/6275531), [ORT change](https://github.com/microsoft/onnxruntime/pull/23827)
 -   2024-11-12 Remove grace-period support for MLTensorUsage - [spec change](https://github.com/webmachinelearning/webnn/pull/754), [Chromium change](https://chromium-review.googlesource.com/c/chromium/src/+/6015318)
 -   2024-10-29 Convert MLOperand methods into readonly attributes - [spec change](https://github.com/webmachinelearning/webnn/pull/774), [Chromium change](https://chromium-review.googlesource.com/c/chromium/src/+/5975719)
 -   2024-09-30 Replace MLContext.compute() with MLContext.dispatch() - [spec change](https://github.com/webmachinelearning/webnn/pull/754), [Chromium change](https://chromium-review.googlesource.com/c/chromium/src/+/5874589), [ORT change](https://github.com/microsoft/onnxruntime/pull/21301/), [sample change](https://github.com/webmachinelearning/webnn-samples/issues/275)


### PR DESCRIPTION
Now that `Float16Array` is an official type enabled by default in Chromium, samples using Uint16Array as raw bit buffers to implement Float16Array may fail.