### PR TITLE
Update ESLint configuration to enable format check during linting

### DIFF
--- a/demos/phi-3-mini/llm.js
+++ b/demos/phi-3-mini/llm.js
@@ -79,7 +79,9 @@ export class LLM {
             ],
         };
 
-        log(`WebNN EP config: ${model} · ${this.dtype} · ${session_options.executionProviders[0].name} · ${session_options.executionProviders[0].deviceType}`);
+        log(
+            `WebNN EP config: ${model} · ${this.dtype} · ${session_options.executionProviders[0].name} · ${session_options.executionProviders[0].deviceType}`,
+        );
 
         const location_type = this.provider == "webnn" ? "ml-tensor" : "gpu-buffer";
         switch (this.provider) {
@@ -89,7 +91,8 @@ export class LLM {
                 session_options.preferredOutputLocation = {};
                 for (let i = 0; i < 32; ++i) {
                     session_options.preferredOutputLocation[`new_present_key_values.${i}.decoder.key`] = location_type;
-                    session_options.preferredOutputLocation[`new_present_key_values.${i}.decoder.value`] = location_type;
+                    session_options.preferredOutputLocation[`new_present_key_values.${i}.decoder.value`] =
+                        location_type;
                 }
                 break;
             case "wasm":
@@ -167,10 +170,8 @@ export class LLM {
             const ort_kv_desc = { dataType: this.dtype, dims: this.kv_dims };
             const input_ml_tensor = await this.ml_context.createTensor(kv_desc);
             for (let i = 0; i < this.num_layers; ++i) {
-                this.feed[`past_key_values.${i}.decoder.key`] =
-                    ort.Tensor.fromMLTensor(input_ml_tensor, ort_kv_desc);
-                this.feed[`past_key_values.${i}.decoder.value`] =
-                    ort.Tensor.fromMLTensor(input_ml_tensor, ort_kv_desc);
+                this.feed[`past_key_values.${i}.decoder.key`] = ort.Tensor.fromMLTensor(input_ml_tensor, ort_kv_desc);
+                this.feed[`past_key_values.${i}.decoder.value`] = ort.Tensor.fromMLTensor(input_ml_tensor, ort_kv_desc);
             }
         } else {
             const kv_num_elements = product(this.kv_dims);
@@ -197,7 +198,6 @@ export class LLM {
                     } else {
                         t.dispose();
                     }
-
                 }
 
                 this.feed[newName] = outputs[name];

--- a/demos/phi-3-mini/main.js
+++ b/demos/phi-3-mini/main.js
@@ -373,7 +373,7 @@ const ui = async () => {
         deviceType = getQueryValue("devicetype").toLowerCase();
     }
 
-    if(getQueryValue("provider")) {
+    if (getQueryValue("provider")) {
         provider = getQueryValue("provider")?.toLowerCase();
     }
 

--- a/demos/sd-turbo/index.js
+++ b/demos/sd-turbo/index.js
@@ -39,10 +39,10 @@ function getConfig() {
         let pair = vars[i].split("=");
         if (pair[0] in config) {
             config[pair[0]] = decodeURIComponent(pair[1]);
-        } else if (pair[0].toLowerCase() === 'devicetype') {
+        } else if (pair[0].toLowerCase() === "devicetype") {
             config.deviceType = decodeURIComponent(pair[1]);
-        } else if (pair[0].toLowerCase() === 'safetychecker') {
-            config.safetyChecker = (decodeURIComponent(pair[1]) === 'true');
+        } else if (pair[0].toLowerCase() === "safetychecker") {
+            config.safetyChecker = decodeURIComponent(pair[1]) === "true";
         } else if (pair[0].length > 0) {
             throw new Error("unknown argument: " + pair[0]);
         }
@@ -960,12 +960,11 @@ const ui = async () => {
     const deviceType = config.deviceType.toLowerCase();
     const provider = config.provider.toLowerCase();
 
-    if (deviceType ===  "cpu" || provider === "wasm") {
+    if (deviceType === "cpu" || provider === "wasm") {
         device.innerHTML = "CPU";
         badge.setAttribute("class", "cpu");
         document.body.setAttribute("class", "cpu");
-    } else if (
-        deviceType === "gpu" || provider === "webgpu") {
+    } else if (deviceType === "gpu" || provider === "webgpu") {
         device.innerHTML = "GPU";
         badge.setAttribute("class", "");
         document.body.setAttribute("class", "gpu");

--- a/demos/segment-anything/index.js
+++ b/demos/segment-anything/index.js
@@ -103,7 +103,7 @@ function getConfig() {
         let pair = vars[i].split("=");
         if (pair[0] in config) {
             config[pair[0]] = decodeURIComponent(pair[1]);
-        } else if (pair[0].toLowerCase() === 'devicetype') {
+        } else if (pair[0].toLowerCase() === "devicetype") {
             config.deviceType = decodeURIComponent(pair[1]);
         } else if (pair[0].length > 0) {
             throw new Error("unknown argument: " + pair[0]);
@@ -631,12 +631,11 @@ const ui = async () => {
     const deviceType = config.deviceType.toLowerCase();
     const provider = config.provider.toLowerCase();
 
-    if (deviceType ===  "cpu" || provider === "wasm") {
+    if (deviceType === "cpu" || provider === "wasm") {
         device.innerHTML = "CPU";
         badge.setAttribute("class", "cpu");
         document.body.setAttribute("class", "cpu");
-    } else if (
-        deviceType === "gpu" || provider === "webgpu") {
+    } else if (deviceType === "gpu" || provider === "webgpu") {
         device.innerHTML = "GPU";
         badge.setAttribute("class", "");
         document.body.setAttribute("class", "gpu");

--- a/demos/whisper-base/main.js
+++ b/demos/whisper-base/main.js
@@ -6,13 +6,7 @@
 //
 
 import { Whisper } from "./whisper.js";
-import {
-    $,
-    getMode,
-    getWebnnStatus,
-    setupORT,
-    showCompatibleChromiumVersion,
-} from "../../assets/js/common_utils.js";
+import { $, getMode, getWebnnStatus, setupORT, showCompatibleChromiumVersion } from "../../assets/js/common_utils.js";
 import { log, logError, concatBuffer, concatBufferArray, logUser } from "./utils.js";
 import VADBuilder, { VADMode, VADEvent } from "./vad/embedded.js";
 import AudioMotionAnalyzer from "./static/js/audioMotion-analyzer.js?min";

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,6 @@
 import globals from "globals";
 import pluginJs from "@eslint/js";
-import eslintConfigPrettier from "eslint-config-prettier";
+import eslintPluginPrettierRecommended from "eslint-plugin-prettier/recommended";
 
 export default [
     {
@@ -11,6 +11,7 @@ export default [
             globals: globals.browser,
         },
     },
+
     pluginJs.configs.recommended,
-    eslintConfigPrettier,
+    eslintPluginPrettierRecommended,
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@eslint/js": "^9.13.0",
         "eslint": "^9.13.0",
-        "eslint-config-prettier": "^9.1.0",
+        "eslint-plugin-prettier": "^5.2.3",
         "globals": "^15.11.0",
         "http-server": "^14.1.1",
         "https-proxy-agent": "^7.0.5",
@@ -226,6 +226,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@pkgr/core": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.1.1.tgz",
+      "integrity": "sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
       }
     },
     "node_modules/@types/estree": {
@@ -703,11 +715,43 @@
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-prettier": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.2.3.tgz",
+      "integrity": "sha512-qJ+y0FfCp/mQYQ/vWQ3s7eUlFEL4PyKfAJxsnYTJ4YT73nsJBWqmEpFryxV9OeUiqmsTsYJ5Y+KDNaeP31wrRw==",
+      "dev": true,
+      "dependencies": {
+        "prettier-linter-helpers": "^1.0.0",
+        "synckit": "^0.9.1"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-plugin-prettier"
+      },
+      "peerDependencies": {
+        "@types/eslint": ">=8.0.0",
+        "eslint": ">=8.0.0",
+        "eslint-config-prettier": "*",
+        "prettier": ">=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/eslint": {
+          "optional": true
+        },
+        "eslint-config-prettier": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-scope": {
@@ -847,6 +891,12 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "node_modules/fast-diff": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.3.0.tgz",
+      "integrity": "sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==",
       "dev": true
     },
     "node_modules/fast-json-stable-stringify": {
@@ -1919,6 +1969,18 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "dev": true,
+      "dependencies": {
+        "fast-diff": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -2195,6 +2257,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/synckit": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.2.tgz",
+      "integrity": "sha512-vrozgXDQwYO72vHjUb/HnFbQx1exDjoKzqx23aXEg2a9VIg2TSFZ8FmeZpTjUCFMYw7mpX4BE2SFu8wI7asYsw==",
+      "dev": true,
+      "dependencies": {
+        "@pkgr/core": "^0.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -2212,6 +2290,12 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@eslint/js": "^9.13.0",
     "eslint": "^9.13.0",
-    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-prettier": "^5.2.3",
     "globals": "^15.11.0",
     "http-server": "^14.1.1",
     "https-proxy-agent": "^7.0.5",


### PR DESCRIPTION
The previous `Prettier` setup didn’t work during the linting check, update it with the `eslint-prettier plugin` to enable proper formatting

@fdwr PTAL thanks
