### PR TITLE
Add ort config of phi-3-mini back

### DIFF
--- a/assets/js/common_utils.js
+++ b/assets/js/common_utils.js
@@ -150,6 +150,11 @@ const KNOWN_COMPATIBLE_ORT_VERSION = {
         stable: STABLE_ORT_VERSION,
         test: TEST_ORT_VERSION,
     },
+    "phi-3-mini": {
+        dev: DEV_ORT_VERSION,
+        stable: STABLE_ORT_VERSION,
+        test: TEST_ORT_VERSION,
+    },
     "text-generation": {
         dev: DEV_ORT_VERSION,
         stable: STABLE_ORT_VERSION,


### PR DESCRIPTION
The original phi-3 mini demo is there but unable to run, add ort config of phi-3-mini back to make it work.

@fdwr PTAL