### PR TITLE
Update the max_cache to 512 for demos/phi-3-mini/

### DIFF
--- a/demos/phi-3-mini/llm.js
+++ b/demos/phi-3-mini/llm.js
@@ -34,7 +34,7 @@ export class LLM {
     dtype = "float16";
     device_type = "gpu";
     max_seq = 128;
-    max_cache = 256;
+    max_cache = 512;
     attn_mask_len = 384;
     start_len = 0;
     ml_context = undefined;


### PR DESCRIPTION
```
max_cache = 256; => 512
https://github.com/microsoft/webnn-developer-preview/blob/main/demos/phi-3-mini/main.js#L212 

max_length: 512,
https://github.com/microsoft/webnn-developer-preview/blob/main/demos/text-generation/main.js#L271C8-L271C25
```

Update the max_cache of demos/phi-3-mini/ to 512 for better performance comparison with demos/text-generation 

@fdwr PTAL

CC @Honry 