### PR TITLE
Add freeDimensionOverrides for MobileNet v2

### DIFF
--- a/demos/image-classification/index.js
+++ b/demos/image-classification/index.js
@@ -103,13 +103,13 @@ const main = async () => {
         },
     };
 
-    if (modelId === "resnet-50") {
-        options.session_options.freeDimensionOverrides = {
-            batch_size: 1,
-            num_channels: 3,
-            height: 224,
-            width: 224,
-        };
+    const dimensionOverrides = {
+        "resnet-50": { batch_size: 1, num_channels: 3, height: 224, width: 224 },
+        "mobilenet-v2": { batch_size: 1 },
+    };
+
+    if (dimensionOverrides[modelId]) {
+        options.session_options.freeDimensionOverrides = dimensionOverrides[modelId];
     }
 
     modelIdSpan.innerHTML = dataType;


### PR DESCRIPTION
Based on https://github.com/microsoft/onnxruntime/issues/25274 , MS suggested using [huggingface.co/onnx-community/mobilenet_v2_1.0_224-ONNX](https://huggingface.co/onnx-community/mobilenet_v2_1.0_224-ONNX) to avoid the webgpu-ep does not implement clip < opset-11 issue. 

The new model has been updated but it requires freeDimensionOverrides. @fdwr PTAL, thanks!

CC @qwu16