### PR TITLE
[SD Turbo] Log each model output for debugging

### DIFF
--- a/demos/sd-turbo/index.js
+++ b/demos/sd-turbo/index.js
@@ -642,7 +642,7 @@ async function generate_image() {
                 latent_sample: new_latents,
             });
             if (config.logOutput) {
-                console.log(`[Model Output][Image ${j + 1}] Vae Decoder - sample:`);
+                console.log(`[Model Output][Image ${j + 1}] VAE Decoder - sample:`);
                 console.log(sample.data);
             }
             let vaeRunTime = (performance.now() - start).toFixed(2);

--- a/demos/sd-turbo/index.js
+++ b/demos/sd-turbo/index.js
@@ -39,8 +39,8 @@ function getConfig() {
 
     for (const key in config) {
         const lowerKey = key.toLowerCase();
-        if (queryParams.has(key) || queryParams.has(lowerKey)) {
-            const value = queryParams.get(key) || queryParams.get(lowerKey);
+        const value = queryParams.get(key) ?? queryParams.get(lowerKey);
+        if (value !== null) {
             if (typeof config[key] === "boolean") {
                 config[key] = value === "true";
             } else if (typeof config[key] === "number") {


### PR DESCRIPTION
Introduce a new url param: 'logOutput' to logging each model output in dev tools for debugging purpose.

BTW, add another param: 'verbose' by default to false to switch logging the verbose info from ort-web, improve the search algorithm of url params by using the modern API `URLSearchParams()`.