### PR TITLE
Redirect the text generation model to Phi-4 Mini by default

### DIFF
--- a/demos/text-generation/llm.js
+++ b/demos/text-generation/llm.js
@@ -14,15 +14,6 @@ import {
     onnxDataCompileProgress,
 } from "./utils.js";
 
-function product(shape) {
-    if (!Array.isArray(shape)) {
-        return 0; // Keep the non-array case returning 0
-    }
-    // A shape of [] should be 1 as a scalar
-    // No need for special empty array check since reduce handles it
-    return shape.reduce((acc, val) => acc * val, 1);
-}
-
 // Class to handle a large language model on top of onnxruntime-web
 export class LLM {
     provider = "webnn";

--- a/demos/text-generation/main.js
+++ b/demos/text-generation/main.js
@@ -452,7 +452,7 @@ const main = async () => {
 
 const ui = async () => {
     if (!getQueryValue("provider") && !getQueryValue("devicetype")) {
-        location.href = `./?provider=${provider}&devicetype=${deviceType}&model=phi3mini`;
+        location.href = `./?provider=${provider}&devicetype=${deviceType}&model=phi4mini`;
         return;
     }
 


### PR DESCRIPTION
1. Redirect the text generation model to Phi-4 Mini by default
2. Fix `the 'product' is defined but never used` lint issue which was used for legacy `demos/phi-3-mini` only

@fdwr PTAL

CC @Honry 