### PR TITLE
[Segment Anything] Optimize the decoder model

### DIFF
--- a/demos/segment-anything/index.js
+++ b/demos/segment-anything/index.js
@@ -127,7 +127,7 @@ function cloneTensor(t) {
 function feedForSam(emb, points, labels) {
     const maskInput = new ort.Tensor(new Float32Array(256 * 256), [1, 1, 256, 256]);
     const hasMask = new ort.Tensor(new Float32Array([0]), [1]);
-    const origianlImageSize = new ort.Tensor(new Float32Array(MODEL_HEIGHT * MODEL_WIDTH), [MODEL_HEIGHT, MODEL_WIDTH]);
+    const originalImageSize = new ort.Tensor(new Float32Array(MODEL_HEIGHT * MODEL_WIDTH), [MODEL_HEIGHT, MODEL_WIDTH]);
     const pointCoords = new ort.Tensor(new Float32Array(points), [1, points.length / 2, 2]);
     const pointLabels = new ort.Tensor(new Float32Array(labels), [1, labels.length]);
 
@@ -137,7 +137,7 @@ function feedForSam(emb, points, labels) {
         point_labels: pointLabels,
         mask_input: maskInput,
         has_mask_input: hasMask,
-        orig_im_size_shape: origianlImageSize,
+        orig_im_size_shape: originalImageSize,
     };
 }
 


### PR DESCRIPTION
The original decoder model has an input `orig_im_size` with shape `[2]` to accept the image size with data: `[height, width]`. Which would lead to some of its following nodes (e.g. `Resize`, `Slice`) have to take dynamic parameters during inference.

Since WebNN doesn't support dynamic `Resize` and `Slice`, there are several ops being fall backed to CPU EP and result in poor performance.

This can be mitigated by inserting an additional `Shape` node to the `orig_im_size` input to change the input shape to `[height, width]`. Therefore WebNN can benefit from constant folding during session creation with `freeDimensionOverrides` option, all those dynamic nodes will finally be eliminated.