### PR TITLE
Optimize the whisper base demo

### DIFF
--- a/demos/whisper-base/main.js
+++ b/demos/whisper-base/main.js
@@ -593,7 +593,7 @@ const main = async () => {
     speech.disabled = true;
     // progress.parentNode.style.display = "none";
 
-    await setupORT("whisper-base", "dev");
+    await setupORT("whisper-base", "test");
     showCompatibleChromiumVersion("whisper-base");
     ort.env.wasm.numThreads = 1;
     ort.env.wasm.simd = true;
@@ -670,6 +670,9 @@ const main = async () => {
     await whisper.create_whisper_processor();
     await whisper.create_whisper_tokenizer();
     await whisper.create_ort_sessions();
+    if (whisper.ioBinding) {
+        await whisper.initialize_preallocated_mltensors();
+    }
     log("Ready to transcribe ...");
     ready();
     context = new AudioContext({


### PR DESCRIPTION
Optimize the whisper base demo:

- Initialize all pre-allocated MLTensors and buffer for optimal real-time performance.
- Set ORT version to `test` until the [fix](https://github.com/microsoft/onnxruntime/pull/25571) is included in the latest dev version.
- Now we can run the demo with IO Binding supporting on the NPU (ORT OpenVINO EP), we have removed the limitation that IO Binding can only run on GPU.

@Honry @fdwr PTAL. cc\ @ibelem Thanks.