### PR TITLE
[text-generation][WebGPU] Fix unexpected result with GQA + FA

### DIFF
--- a/demos/text-generation/llm.js
+++ b/demos/text-generation/llm.js
@@ -213,8 +213,8 @@ export class LLM {
                     bufferSize,
                 );
 
-                // The GQA spec suggests to use the same tensor for both present_key / present_value
-                // and past_key / past_value if the total_sequence_length = max_sequence_length
+                // The GQA spec suggests to use the same tensor for both present_key & present_value
+                // and past_key & past_value if the total_sequence_length = max_sequence_length
                 // in order to save GPU memory.
                 this.fetches[`present.${i}.key`] = this.feed[`past_key_values.${i}.key`];
                 this.fetches[`present.${i}.value`] = this.feed[`past_key_values.${i}.value`];


### PR DESCRIPTION
Apply fix suggested by https://github.com/microsoft/onnxruntime/issues/26064#issuecomment-3336869965 to fix the issue that GQA will produce unexpected result with FlashAttention applied.

The GQA spec suggests to use the same tensor for both present_key / present_value and past_key / past_value if the total_sequence_length = max_sequence_length in order to save GPU memory.